### PR TITLE
Reworking the runtime

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,17 +59,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: ${{ matrix.features }}
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.features }}
-
-      - name: Test all benches
-        if: matrix.benches
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --benches ${{ matrix.features }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,6 @@ jobs:
             rust: beta
           - build: nightly
             rust: nightly
-            benches: true
-
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -46,9 +46,9 @@ attempts = 0
     * `never`: It won't be restarted, no matter what's the exit status. Please check the attempts parameter below.
 
 * **`backoff` = `string`**: Use this time before retrying restarting the service. 
-* **`attempts` = `number`**: How many attempts before considering the service as FinishedFailed. Default is 10.
+* **`attempts` = `number`**: How many attempts to start the service before considering it as FinishedFailed. Default is 10.
 Attempts are useful if your service is failing too quickly. If you're in a start-stop loop, this will put and end to it.
-If a service has failed too quickly, it will be restarted even if the policy is `never`. 
+If a service has failed too quickly and attempts > 0, it will be restarted even if the strategy is `never`. 
 And if the attempts are over, it won't never be restarted even if the restart policy is: On-Failure/ Always.
 
 The delay between attempts is calculated as: `backoff * attempts_made + start-delay`. For instance, using:

--- a/src/horust/bus.rs
+++ b/src/horust/bus.rs
@@ -61,6 +61,7 @@ impl<T> BusConnector<T> {
     }
 
     /// Blocking
+    #[cfg(test)]
     pub fn get_n_events_blocking(&self, quantity: usize) -> Vec<T> {
         self.receiver.iter().take(quantity).collect()
     }

--- a/src/horust/formats/mod.rs
+++ b/src/horust/formats/mod.rs
@@ -9,10 +9,12 @@ pub type ComponentName = String;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     PidChanged(ServiceName, Pid),
+    ServiceStarted(ServiceName),
     StatusChanged(ServiceName, ServiceStatus),
     ServiceExited(ServiceName, i32),
     ForceKill(ServiceName),
     Kill(ServiceName),
+    SpawnFailed(ServiceName),
     Run(ServiceName),
     Exiting(ComponentName, ExitStatus),
     ShuttingDownInitiated,

--- a/src/horust/healthcheck/checks.rs
+++ b/src/horust/healthcheck/checks.rs
@@ -55,7 +55,12 @@ impl Check for FilePathCheck {
     fn prepare(&self, healthiness: &Healthiness) -> Result<(), std::io::Error> {
         //TODO: check if user has permissions to remove this file.
         if let Some(file_path) = healthiness.file_path.as_ref() {
-            std::fs::remove_file(file_path)
+            // If it's a dir, remove_file will fail.
+            if file_path.exists() {
+                std::fs::remove_file(file_path)
+            } else {
+                Ok(())
+            }
         } else {
             Ok(())
         }

--- a/src/horust/runtime/repo.rs
+++ b/src/horust/runtime/repo.rs
@@ -25,11 +25,6 @@ impl Repo {
         self.bus.try_get_events()
     }
 
-    /// Blocking
-    pub(crate) fn get_n_events_blocking(&mut self, quantity: usize) -> Vec<Event> {
-        self.bus.get_n_events_blocking(quantity)
-    }
-
     pub fn all_have_finished(&self) -> bool {
         self.services
             .iter()

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -11,6 +11,7 @@ use utils::*;
 // with assert.success() and assert.failure()
 fn restart_attempts(should_contain: bool, attempts: u32) {
     let (mut cmd, temp_dir) = get_cli();
+
     let failing_once_script = format!(
         r#"#!/usr/bin/env bash
 if [ ! -f {0} ]; then
@@ -22,9 +23,15 @@ echo "File is there"
     );
     let service = format!(
         r#"
+[healthiness]
+file-path = "{}"
 [restart]
 attempts = {}
 "#,
+        temp_dir
+            .path()
+            .join("valid-path-but-shouldnt-exists.temp")
+            .display(),
         attempts
     );
     store_service(
@@ -42,7 +49,9 @@ attempts = {}
 
 #[test]
 fn test_restart_attempts() {
+    // Should try to check for the presence of a file, since it's not there it will fail.
     restart_attempts(false, 0);
+    // Now we have a second shot, since the file was created the first time this will succeed.
     restart_attempts(true, 1);
 }
 

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -62,7 +62,7 @@ fn test_restart_strategy_on_failure() {
     let failing_once_script = format!(
         r#"#!/usr/bin/env bash
 if [ ! -f {0} ]; then
-    touch {0} && exit 1
+    touch {0} && sleep 1 && exit 1
 fi
 "#,
         temp_dir.path().join("file.temp").display()

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -42,12 +42,15 @@ pub fn store_service(
 pub fn get_cli() -> (Command, TempDir) {
     let temp_dir = TempDir::new("horust").unwrap();
     let mut cmd = Command::cargo_bin("horust").unwrap();
-    cmd.current_dir(&temp_dir).args(vec![
-        "--services-path",
-        temp_dir.path().display().to_string().as_str(),
-    ]);
-    //.stdout(Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
-    //.stderr(std::process::Stdio::from(std::fs::File::create("/tmp/stderr").unwrap(),));
+    cmd.current_dir(&temp_dir)
+        .args(vec![
+            "--services-path",
+            temp_dir.path().display().to_string().as_str(),
+        ])
+        //.stdout(Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
+        .stderr(std::process::Stdio::from(
+            std::fs::File::create("/tmp/stderr").unwrap(),
+        ));
     (cmd, temp_dir)
 }
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -42,15 +42,12 @@ pub fn store_service(
 pub fn get_cli() -> (Command, TempDir) {
     let temp_dir = TempDir::new("horust").unwrap();
     let mut cmd = Command::cargo_bin("horust").unwrap();
-    cmd.current_dir(&temp_dir)
-        .args(vec![
-            "--services-path",
-            temp_dir.path().display().to_string().as_str(),
-        ])
-        //.stdout(Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
-        .stderr(std::process::Stdio::from(
-            std::fs::File::create("/tmp/stderr").unwrap(),
-        ));
+    cmd.current_dir(&temp_dir).args(vec![
+        "--services-path",
+        temp_dir.path().display().to_string().as_str(),
+    ]);
+    //.stdout(Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
+    //.stderr(std::process::Stdio::from(std::fs::File::create("/tmp/stderr").unwrap(),));
     (cmd, temp_dir)
 }
 


### PR DESCRIPTION
The idea is that the runtime will emit status changes. Status changes might be
initiated by external events, or by internal triggers. This new design allowed
to find a couple of well hidden concurrency issues.