### PR TITLE
Wait and kill all processes after all services stopped.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-* Only if horust's pid is 1: after everything service has exited, run kill(-1, SIGTERM), then sleep(1), and then kill(-1, SIGKILL) 
-  In order to correctly handle double forking and forks in general. 
 * Add another state "InitialRestart", after initial, for restarting processes. So from SUCCESS / FAILED if the process is set to be restart,
   it will transition back to InitialRestart.
 * Count all time the unhealthy events, if threshold is passed and 

--- a/src/horust/bus.rs
+++ b/src/horust/bus.rs
@@ -84,7 +84,7 @@ impl<T> BusConnector<T> {
 #[cfg(test)]
 mod test {
     use crate::horust::bus::{Bus, BusConnector};
-    use crate::horust::formats::{Event, ServiceStatus, Component};
+    use crate::horust::formats::{Component, Event, ServiceStatus};
     use crossbeam::channel;
     use std::thread;
     use std::time::Duration;

--- a/src/horust/bus.rs
+++ b/src/horust/bus.rs
@@ -84,7 +84,7 @@ impl<T> BusConnector<T> {
 #[cfg(test)]
 mod test {
     use crate::horust::bus::{Bus, BusConnector};
-    use crate::horust::formats::{Event, ServiceStatus};
+    use crate::horust::formats::{Event, ServiceStatus, Component};
     use crossbeam::channel;
     use std::thread;
     use std::time::Duration;
@@ -129,8 +129,8 @@ mod test {
             assert_eq!(a.try_get_events().len(), 1);
             assert_eq!(b.try_get_events().len(), 1);
 
-            a.send_event(Event::new_exit_success("serv"));
-            b.send_event(Event::new_exit_success("serv"));
+            a.send_event(Event::new_exit_success(Component::Runtime));
+            b.send_event(Event::new_exit_success(Component::Healthchecker));
             sender.send(()).unwrap();
         });
 
@@ -150,8 +150,8 @@ mod test {
         a.send_event(ev.clone());
         assert_eq!(a.receiver.recv().unwrap(), ev);
         assert_eq!(b.receiver.recv().unwrap(), ev);
-        a.send_event(Event::new_exit_success("serv"));
-        b.send_event(Event::new_exit_success("serv"));
+        a.send_event(Event::new_exit_success(Component::Runtime));
+        b.send_event(Event::new_exit_success(Component::Healthchecker));
         drop(a);
         drop(b);
         receiver
@@ -175,7 +175,7 @@ mod test {
                 .expect("test didn't terminate in time, so chan is closed!");
         });
         let ev = Event::new_status_changed(&"sample".to_string(), ServiceStatus::Initial);
-        let exit_ev = Event::new_exit_success("serv");
+        let exit_ev = Event::new_exit_success(Component::Runtime);
 
         for _i in 0..100 {
             last.send_event(ev.clone());
@@ -188,7 +188,7 @@ mod test {
                 assert_eq!(recv.receiver.recv().unwrap(), exit_ev);
             }
         }
-        last.send_event(Event::new_exit_success("serv"));
+        last.send_event(Event::new_exit_success(Component::Healthchecker));
         drop(connectors);
         drop(last);
         receiver

--- a/src/horust/formats/mod.rs
+++ b/src/horust/formats/mod.rs
@@ -4,7 +4,12 @@ pub use horust_config::HorustConfig;
 use nix::unistd::Pid;
 pub use service::*;
 
-pub type ComponentName = String;
+#[derive(Debug, Clone, PartialEq)]
+pub enum Component {
+    Reaper,
+    Runtime,
+    Healthchecker
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
@@ -16,7 +21,7 @@ pub enum Event {
     Kill(ServiceName),
     SpawnFailed(ServiceName),
     Run(ServiceName),
-    Exiting(ComponentName, ExitStatus),
+    Exiting(Component, ExitStatus),
     ShuttingDownInitiated,
     HealthCheck(ServiceName, HealthinessStatus),
     // TODO: to allow changes of service at runtime:
@@ -36,8 +41,8 @@ impl Event {
     pub(crate) fn new_force_kill(service_name: &ServiceName) -> Self {
         Self::ForceKill(service_name.clone())
     }
-    pub(crate) fn new_exit_success(comp_name: &str) -> Self {
-        Event::Exiting(comp_name.into(), ExitStatus::Successful)
+    pub(crate) fn new_exit_success(component: Component) -> Self {
+        Event::Exiting(component, ExitStatus::Successful)
     }
 }
 

--- a/src/horust/formats/mod.rs
+++ b/src/horust/formats/mod.rs
@@ -8,7 +8,7 @@ pub use service::*;
 pub enum Component {
     Reaper,
     Runtime,
-    Healthchecker
+    Healthchecker,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/horust/healthcheck/mod.rs
+++ b/src/horust/healthcheck/mod.rs
@@ -1,7 +1,5 @@
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{
-    Event, Healthiness, HealthinessStatus, Service, ServiceName, ServiceStatus,
-};
+use crate::horust::formats::{Event, Healthiness, HealthinessStatus, Service, ServiceName, ServiceStatus, Component};
 use crossbeam::channel::{unbounded, Receiver, RecvTimeoutError};
 use std::time::Duration;
 
@@ -110,7 +108,7 @@ fn run(bus: BusConnector<Event>, services: Vec<Service>) {
             _ => {}
         }
     }
-    bus.send_event(Event::new_exit_success("Healthchecker"));
+    bus.send_event(Event::new_exit_success(Component::Healthchecker));
 }
 
 /// Setup require for the service, before running the healthchecks and starting the service

--- a/src/horust/healthcheck/mod.rs
+++ b/src/horust/healthcheck/mod.rs
@@ -1,5 +1,7 @@
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{Event, Healthiness, HealthinessStatus, Service, ServiceName, ServiceStatus, Component};
+use crate::horust::formats::{
+    Component, Event, Healthiness, HealthinessStatus, Service, ServiceName, ServiceStatus,
+};
 use crossbeam::channel::{unbounded, Receiver, RecvTimeoutError};
 use std::time::Duration;
 

--- a/src/horust/reaper.rs
+++ b/src/horust/reaper.rs
@@ -1,10 +1,10 @@
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{Event, ServiceName, ServiceStatus, Component};
+use crate::horust::formats::{Component, Event, ServiceName, ServiceStatus};
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd;
 use nix::unistd::Pid;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
-use nix::unistd;
 
 pub(crate) fn spawn(bus: BusConnector<Event>) {
     std::thread::spawn(move || {
@@ -118,11 +118,14 @@ pub(crate) fn supervisor_thread(bus: BusConnector<Event>) {
         if is_init && repo.runtime_exited {
             break;
         }
-        if !is_init && repo.is_shutting_down && repo.possibly_running.is_empty() && repo.pids_map.is_empty() {
+        if !is_init
+            && repo.is_shutting_down
+            && repo.possibly_running.is_empty()
+            && repo.pids_map.is_empty()
+        {
             debug!("Breaking the loop..");
             break;
         }
-
 
         std::thread::sleep(Duration::from_millis(300))
     }

--- a/src/horust/reaper.rs
+++ b/src/horust/reaper.rs
@@ -1,9 +1,10 @@
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{Event, ServiceName, ServiceStatus};
+use crate::horust::formats::{Event, ServiceName, ServiceStatus, Component};
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
 use nix::unistd::Pid;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
+use nix::unistd;
 
 pub(crate) fn spawn(bus: BusConnector<Event>) {
     std::thread::spawn(move || {
@@ -19,6 +20,7 @@ struct Repo {
     pids_map: HashMap<Pid, ServiceName>,
     bus: BusConnector<Event>,
     is_shutting_down: bool,
+    runtime_exited: bool,
 }
 
 impl Repo {
@@ -28,6 +30,7 @@ impl Repo {
             pids_map: HashMap::new(),
             bus,
             is_shutting_down: false,
+            runtime_exited: false,
         }
     }
 
@@ -49,6 +52,9 @@ impl Repo {
             }
             Event::PidChanged(service_name, pid) => {
                 self.pids_map.insert(pid, service_name);
+            }
+            Event::Exiting(component, _status) if component == Component::Runtime => {
+                self.runtime_exited = true;
             }
             Event::StatusChanged(service_name, status) => {
                 if vec![ServiceStatus::Starting, ServiceStatus::Initial].contains(&status) {
@@ -107,12 +113,18 @@ pub(crate) fn supervisor_thread(bus: BusConnector<Event>) {
                 !repo.possibly_running.is_empty()
             }
         });
-
-        if repo.is_shutting_down && repo.possibly_running.is_empty() && repo.pids_map.is_empty() {
+        let init_pid = unistd::Pid::from_raw(1.into());
+        let is_init = init_pid == unistd::getpid();
+        if is_init && repo.runtime_exited {
+            break;
+        }
+        if !is_init && repo.is_shutting_down && repo.possibly_running.is_empty() && repo.pids_map.is_empty() {
             debug!("Breaking the loop..");
             break;
         }
+
+
         std::thread::sleep(Duration::from_millis(300))
     }
-    repo.send_ev(Event::new_exit_success("Reaper"));
+    repo.send_ev(Event::new_exit_success(Component::Reaper));
 }

--- a/src/horust/runtime/mod.rs
+++ b/src/horust/runtime/mod.rs
@@ -1,6 +1,8 @@
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{Event, ExitStatus, FailureStrategy, HealthinessStatus,
-                             RestartStrategy, Service, ServiceName, ServiceStatus, Component};
+use crate::horust::formats::{
+    Component, Event, ExitStatus, FailureStrategy, HealthinessStatus, RestartStrategy, Service,
+    ServiceName, ServiceStatus,
+};
 use crate::horust::{healthcheck, signal_handling};
 use nix::sys::signal;
 use std::fmt::Debug;
@@ -12,8 +14,8 @@ mod process_spawner;
 mod service_handler;
 use service_handler::ServiceHandler;
 mod repo;
-use repo::Repo;
 use nix::unistd;
+use repo::Repo;
 
 #[derive(Debug)]
 pub struct Runtime {
@@ -332,7 +334,8 @@ impl Runtime {
         if !self.is_shutting_down {
             self.repo.send_ev(Event::ShuttingDownInitiated);
         }
-        self.repo.send_ev(Event::new_exit_success(Component::Runtime));
+        self.repo
+            .send_ev(Event::new_exit_success(Component::Runtime));
         return res;
     }
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -46,12 +46,12 @@ pub fn get_cli() -> (Command, TempDir) {
         "--services-path",
         temp_dir.path().display().to_string().as_str(),
     ]);
-    //.stdout(Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
+    //.stdout(std::process::Stdio::from(std::fs::File::create("/tmp/stdout").unwrap()))
     //.stderr(std::process::Stdio::from(std::fs::File::create("/tmp/stderr").unwrap(),));
     (cmd, temp_dir)
 }
 
-/// Run the cmd and send a message on receiver when it's done.
+/// Run the cmd in a new process and send a message on receiver when it's done.
 /// This allows for ensuring termination of a test.
 pub fn run_async(cmd: &mut Command, should_succeed: bool) -> RecvWrapper {
     println!("Cmd: {:?}", cmd);


### PR DESCRIPTION
Only if horust's pid is 1: 
after all the services have exited, run kill(-1, SIGTERM), then sleep(1), and then kill(-1, SIGKILL) in order to correctly handle double forking and forks in general. 