### PR TITLE
First pass at option for setting threshold for failed healthchecks

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -75,10 +75,12 @@ immediately pass to the running state.
 [healthiness]
 http-endpoint = "http://localhost:8080/healthcheck"
 file-path = "/var/myservice/up"
+max-failed-http-requests = 2
 ```
  * **`http-endpoint` = `<http endpoint>`**: It will send an HEAD request to the specified http endpoint. 200 means the service is healthy, otherwise it will change the status to failure.
     This requires horust to be built with the `http-healthcheck` feature (included by default).
  * **`file-path` = `/path/to/file`**: Before running the service, it will remove this file if it exists. Then, as soon as this file is created, the service will be considered running. 
+ * **`max-failed-http-requests` = `2`**: The maximum amount of failed HTTP requests to make before considering a service dead.
  * You can check the healthiness of your system using an http endpoint or a flag file.
  * You can use the enforce dependency to kill every dependent system.
 

--- a/src/horust/bus.rs
+++ b/src/horust/bus.rs
@@ -1,7 +1,7 @@
 //! A simple bus implementation: distributes the messages among the queues
 //! There is one single input pipe (`public_sender` ; `receiver`). The sender side is shared among
 //! all the publishers. The bus reads from the receiver, and publishes to all the `senders`.
-//! This is a very simple wrapper around crossbeam, that allows multiple sender send messages which
+//! This is a very simple wrapper around crossbeam, that allows multiple senders send messages which
 //! will arrive to every receiver. For this reason, the message should implement Clone.
 //!
 

--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -27,6 +27,7 @@ attempts = 0
 [healthiness]
 http-endpoint = "http://localhost:8080/healthcheck"
 file-path = "/var/myservice/up"
+max-failed-http-requests = 2
 
 [failure]
 successful-exit-code = [ 0, 1, 255]
@@ -324,6 +325,7 @@ impl Environment {
 pub struct Healthiness {
     pub http_endpoint: Option<String>,
     pub file_path: Option<PathBuf>,
+    pub max_failed_http_requests: Option<usize>,
 }
 
 impl Default for Healthiness {
@@ -331,6 +333,7 @@ impl Default for Healthiness {
         Self {
             http_endpoint: None,
             file_path: None,
+            max_failed_http_requests: None,
         }
     }
 }
@@ -679,6 +682,7 @@ mod test {
             healthiness: Healthiness {
                 http_endpoint: Some("http://localhost:8080/healthcheck".into()),
                 file_path: Some("/var/myservice/up".into()),
+                max_failed_http_requests: Some(2),
             },
             signal_rewrite: None,
             failure: Failure {

--- a/src/horust/mod.rs
+++ b/src/horust/mod.rs
@@ -59,7 +59,7 @@ impl Horust {
         runtime::init();
 
         let mut dispatcher = Bus::new();
-        debug!("Services: {:?}", self.services);
+        println!("Services: {:?}", self.services);
         // Spawn helper threads:
         healthcheck::spawn(dispatcher.join_bus(), self.services.clone());
         let handle = runtime::spawn(dispatcher.join_bus(), self.services.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use horust::Horust;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-#[macro_use]
-extern crate log;
+// #[macro_use]
+// extern crate log;
 
 #[derive(StructOpt, Debug)]
 #[structopt(author, about)]
@@ -39,7 +39,7 @@ fn main() -> Result<(), horust::HorustError> {
     env_logger::init_from_env(env);
 
     let opts = Opts::from_args();
-
+    println!("Horust is now running");
     if opts.sample_service {
         println!("{}", horust::get_sample_service());
         return Ok(());
@@ -48,7 +48,7 @@ fn main() -> Result<(), horust::HorustError> {
     let config = HorustConfig::load_and_merge(opts.horust_config, &opts.config_path)?;
 
     let mut horust = if !opts.command.is_empty() {
-        debug!("Running command: {:?}", opts.command);
+        println!("Running command: {:?}", opts.command);
 
         Horust::from_command(
             opts.command
@@ -56,7 +56,7 @@ fn main() -> Result<(), horust::HorustError> {
                 .fold(String::new(), |acc, w| format!("{} {}", acc, w)),
         )
     } else {
-        debug!(
+        println!(
             "Loading services from directory: {}",
             opts.services_path.display()
         );


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should fix #36.



### Description
<!--- Describe your changes in detail -->

This is a _very_ rough attempt at figuring out how the program structure works. It's still missing proper tests, and is not ready for review.

Please note that I've changed some `debug()!` macros to `println!()` macros - I couldn't get `RUST_LOG=debug ./horust` to work for some reason, but wanted to make sure the execution followed the path I _thought_ it took. Will fix before actually merging, of course. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
