### PR TITLE
Multiple source dirs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4,6 +4,7 @@
 * [State machine](#state-machine)
 * [Horust's configuration](#horust-configuration)
 * [Single command](#single-command)
+* [Multiple service directories](#multiple-service-directories)
 * [Plugins](#plugins)
 * [Checking system status](#checking-system-status)
 
@@ -190,6 +191,16 @@ command= "bash /tmp/myscript.sh"
 ```
 This will run the specified command as a one shot service, so it won't be restarted after exiting.
 Commands have precedence over services, so if you specify both a command and a services-path, the command will be executed and the services path is ignored.
+
+## Multiple service directories
+
+Horust supports more than one service directory by accepting more than one `--services-path` arguemts.
+```sh
+horust --services-path ./services/core --services-path ./services/extra
+```
+
+These directories are loaded at once and treated just like all `*.toml` files were in single shared directory.
+It means that for example service from `./services/extra` can depend on service from `./services/core`.
 
 ## Plugins
 WIP. Horust works via message passing, so it should be fairly easy to have additional components connected to its bus.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -194,7 +194,7 @@ Commands have precedence over services, so if you specify both a command and a s
 
 ## Multiple service directories
 
-Horust supports more than one service directory by accepting more than one `--services-path` arguemts.
+Horust supports more than one service directory by accepting more than one `--services-path` arguments.
 ```sh
 horust --services-path ./services/core --services-path ./services/extra
 ```

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -38,6 +38,20 @@ pub fn store_service(
     service_name
 }
 
+pub fn get_cli_multiple() -> (Command, TempDir, TempDir) {
+    let temp_dir = TempDir::new("horust").unwrap();
+    let temp_dir_2 = TempDir::new("horust_2").unwrap();
+    let mut cmd = Command::cargo_bin("horust").unwrap();
+    cmd.current_dir(&temp_dir).args(vec![
+        "--services-path",
+        temp_dir.path().display().to_string().as_str(),
+        "--services-path",
+        temp_dir_2.path().display().to_string().as_str(),
+    ]);
+
+    (cmd, temp_dir, temp_dir_2)
+}
+
 pub fn get_cli() -> (Command, TempDir) {
     let temp_dir = TempDir::new("horust").unwrap();
     let mut cmd = Command::cargo_bin("horust").unwrap();


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #55 

### Description
* Change --service-path to accept multiple `PathBuf`
* Add `Horust::fetch_service_dirs` method
* Keep in memory list of directories, not an option

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I tested it manually on Linux machine plus I created a test that checks if all services were loaded from two different locations.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
