### PR TITLE
Fix: Bus didn't send events to all receivers

### DIFF
--- a/src/horust/bus.rs
+++ b/src/horust/bus.rs
@@ -12,6 +12,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+/// Bus state shared between `Bus` and all `BusConnector` instances.
+/// It contains all necessary components to send data and join the bus.
 #[derive(Clone)]
 pub struct SharedState<T>
 where
@@ -35,8 +37,6 @@ where
 
         let id = senders.len() as u64;
         senders.push((id, sender));
-
-        drop(senders);
 
         BusConnector::new(receiver, id, self.clone())
     }

--- a/src/horust/healthcheck/mod.rs
+++ b/src/horust/healthcheck/mod.rs
@@ -82,7 +82,7 @@ fn run(bus: BusConnector<Event>, services: Vec<Service>) {
             Event::StatusChanged(s_name, ServiceStatus::Started) => {
                 let (worker_notifier, work_done_rcv) = unbounded();
                 let service = get_service(&s_name);
-                let w = Worker::new(service, bus.clone(), work_done_rcv);
+                let w = Worker::new(service, bus.join_bus(), work_done_rcv);
                 let handle = w.spawn_thread();
                 workers.insert(s_name, (worker_notifier, handle));
             }

--- a/src/horust/mod.rs
+++ b/src/horust/mod.rs
@@ -75,7 +75,7 @@ impl Horust {
         }
         supervisor::init();
 
-        let mut dispatcher = Bus::new(true);
+        let dispatcher = Bus::new(true);
         debug!("Services: {:?}", self.services);
         // Spawn helper threads:
         healthcheck::spawn(dispatcher.join_bus(), self.services.clone());

--- a/src/horust/supervisor/mod.rs
+++ b/src/horust/supervisor/mod.rs
@@ -131,7 +131,7 @@ impl Supervisor {
                 process_spawner::spawn_fork_exec_handler(
                     service_handler.service().clone(),
                     backoff,
-                    self.repo.bus.clone(),
+                    self.repo.bus.join_bus(),
                 );
                 evs
             }

--- a/src/horust/supervisor/repo.rs
+++ b/src/horust/supervisor/repo.rs
@@ -5,7 +5,7 @@ use crate::horust::Event;
 use nix::unistd::Pid;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Repo {
     pub services: HashMap<ServiceName, ServiceHandler>,
     pub(crate) bus: BusConnector<Event>,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #58 

### Description
In few places there was a `.clone()` on the `BusConnector<T>`.
Unfortunately the `.clone()` created a round-robin kind of message sending instead of the broadcast.
It means that not every thread would receive all messages.

I noticed that any thread can request a `join_bus()`, even after the application startup.
It required creating an `Arc<Mutex<>>` on a list of all senders because this list can be modified in a runtime.
It means there is some performance loss, but I believe correctness is more important.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
I tested it manually, see #58. But also I wrote a unit test to prove that `Bus` is now working as intended - every time in broadcast mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
