### PR TITLE
--services-path now supports file as input parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "horust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horust"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Federico Ponzi <federico.ponzi92@gmail.com>"]
 description = "A complete supervisor and init system, designed for running in containers."
 edition = "2018"

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,18 +2,18 @@
 ## Table of contents:
 * [Service configuration](#service-configuration)
 * [State machine](#state-machine)
-* [Horust's configuration](#horust-configuration)
-* [Single command](#single-command)
+* [Horust's configuration](#horusts-configuration)
+* [Running a single command](#running-a-single-command)
 * [Multiple service directories](#multiple-service-directories)
-* [Plugins](#plugins)
-* [Checking system status](#checking-system-status)
+* [Plugins (WIP)](#plugins-wip)
+* [Checking system status (WIP) ](#checking-system-status-wip)
 
 When starting horust, you can optionally specify where it should look for services and uses `/etc/horust/services` by default.
 
 ## Service configuration
 This section describes all the possible options you can put in a service.toml file.
 You should create one different service.toml for each command you want to run.
-A part from the `user` parameter, everything should work even with an unprivileged user.
+Apart from the `user` parameter, everything should work even with an unprivileged user.
 
 ### Service templating
 Services can, but not have to, be templated. Currently, this feature works only via environment variables. The templating engine uses [bash expansion mechanism](https://docs.rs/shellexpand/2.1.0/shellexpand/). Each part of the service configuration can be used in tandem with the templating. Additionally, multiple variables can be safely used if needed. The engine does not support processing the shell queries, for example `$(cat /proc/config.gz)` will not be processed and will be used on face value.
@@ -44,9 +44,9 @@ working-directory = "/tmp/"
 * **`command` = `string`**: Specify a command to run, or a full path. You can also add arguments. If a full path is not provided, the binary will be searched using the $PATH env variable.
 * **`start-after` = `[list<ServiceName>`**: Start after these other services. User their filename (e.g. `first.toml`).
 If service `a` should start after service `b`, then `a` will be started as soon as `b` is considered Running or Finished. 
-If `b` enters in a FinishedFailed state (finished in an unsuccessful manner), `a` might not start at all. 
+If `b` goes in a `FinishedFailed` state (finished in an unsuccessful manner), `a` might not start at all. 
 * **`start-delay` = `time`**: Start this service with the specified delay. Check how to specify times [here](https://github.com/tailhook/humantime/blob/49f11fdc2a59746085d2457cb46bce204dec746a/src/duration.rs#L338) 
-* **`stdout` = `STDOUT|STDERR|file-path`**: Redirect stdout of this service. STDOUT and STDERR are special strings, pointing to stdout and stderr respectively. Otherwise, a file path is a assumed.
+* **`stdout` = `STDOUT|STDERR|file-path`**: Redirect stdout of this service. STDOUT and STDERR are special strings, pointing to stdout and stderr respectively. Otherwise, a file path is assumed.
 * **`stderr` = `STDOUT|STDERR|file-path`**: Redirect stderr of this service. Read `stdout` above for a complete reference.
 * **`user` = `uid|username`**: Will run this service as this user. Either an uid or a username (check it in /etc/passwd)
 * **`working-directory` = `string`**: Will run this command in this directory.
@@ -61,14 +61,14 @@ attempts = 0
 * **`strategy` = `always|on-failure|never`**: Defines the restart strategy.
 
     * `always`: Failure or Success, it will be always restarted
-    * `on-failure`: Only if it has failed. Please check the attempts parameter below.
-    * `never`: It won't be restarted, no matter what's the exit status. Please check the attempts parameter below.
+    * `on-failure`: Only if it has failed. Please check the `attempts` parameter below.
+    * `never`: It won't be restarted, no matter what's the exit status. Please check the `attempts` parameter below.
 
 * **`backoff` = `string`**: Use this time before retrying restarting the service. 
 * **`attempts` = `number`**: How many attempts to start the service before considering it as FinishedFailed. Default is 10.
 Attempts are useful if your service is failing too quickly. If you're in a start-stop loop, this will put and end to it.
 If a service has failed too quickly and attempts > 0, it will be restarted even if the strategy is `never`. 
-And if the attempts are over, it won't never be restarted even if the restart policy is: On-Failure/ Always.
+And if the attempts are over, it will never be restarted even if the restart policy is: `On-Failure`/`Always`.
 
 The delay between attempts is calculated as: `backoff * attempts_made + start-delay`. For instance, using:
 * backoff = 1s
@@ -78,11 +78,11 @@ The delay between attempts is calculated as: `backoff * attempts_made + start-de
 Will wait 1 second and then start the service. If it doesn't start:
 * 1st attempt will start after 1*1 + 1 = 2 seconds.
 * 2nd attempt will start after 1*2 + 1 = 3 seconds.
-* 3th and last attempt will start after 1*3 +1 = 4 seconds. 
+* 3d and last attempt will start after 1*3 +1 = 4 seconds. 
 
 If the attempts are over, then the service will be considered FailedFinished and won't be restarted.
 The attempt count is reset as soon as the service's state changes to running.
-This state change is driven by the healthcheck component, and a service with no healthcheck will be considered as Healthy and it will
+This state change is driven by the health-check component, and a service with no health-check will be considered as `Healthy` and it will
 immediately pass to the running state.
 
 ### Healthiness Check
@@ -95,8 +95,8 @@ max-failed = 3
  * **`http-endpoint` = `<http endpoint>`**: It will send an HEAD request to the specified http endpoint. 200 means the service is healthy, otherwise it will change the status to failure.
     This requires horust to be built with the `http-healthcheck` feature (included by default).
  * **`file-path` = `/path/to/file`**: Before running the service, it will remove this file if it exists. Then, as soon as this file is created, the service will be considered running. 
- * **`max-failed` = `i32`**: How many unhealthy healthchecks in a row are allowed before considering the service failed.
- * You can check the healthiness of your system using an http endpoint or a flag file.
+ * **`max-failed` = `i32`**: How many unhealthy health-checks in a row are allowed before considering the service failed.
+ * You can check the healthiness of your system using a http endpoint or a flag file.
  * You can use the enforce dependency to kill every dependent system.
 
 ### Failure section
@@ -106,7 +106,7 @@ successful-exit-code = [ 0, 1, 255]
 strategy = "ignore"
 ```
 * **`successful-exit-code` = `[\<int>]`**: A comma separated list of exit code. 
-Usually a program is considered failed if its exit code is different than zero. But not all fails are the same.
+Usually a program is considered failed if its exit code is different from zero. But not all fails are the same.
 By using this parameter, you can specify which exit codes will make this service considered as failed.
 
 * **`strategy` = `shutdown|kill-dependents|ignore`**': We might want to kill the whole system, or part of it, if some service fails. Default: `ignore`
@@ -130,7 +130,7 @@ Regardless the value of keep-env, the following keys will be updated / defined:
 * `PATH`
 Use `re-export` for keeping them.
 * **`re-export` = `[\<string>]`**: Environment variables to keep and re-export.
-This is useful for fine-grained exports or if you want for example to rexport the `PATH`.
+This is useful for fine-grained exports or if you want for example to re-export the `PATH`.
 * **`additional` = `{ key = <string> }`**: Defined as key-values, other environment variables to use.
 
 ### Termination section
@@ -179,8 +179,7 @@ unsuccessful-exit-finished-failed = true
 All the parameters can be passed via the cli (use `horust --help`) or via a config file.
 The default path for the config file is `/etc/horust/horust.toml`.
 
-## Single command
-It's already supported, but I think it needs some love.
+## Running a single command
 You can wrap a single command with horust by running:
 ``` bash
 ./horust -- bash /tmp/myscript.sh
@@ -190,22 +189,25 @@ This is equivalent to running a single service defined as:
 command= "bash /tmp/myscript.sh"
 ```
 This will run the specified command as a one shot service, so it won't be restarted after exiting.
-Commands have precedence over services, so if you specify both a command and a services-path, the command will be executed and the services path is ignored.
+
+_Commands have precedence over services, so if you specify both a command and a services-path, the command will be executed and the `--services-path` is ignored._
 
 ## Multiple service directories
+You can you use the `--services-path` parameter to specify either a directory containing .toml services to run, or 
+point it to a .toml service file to run.
 
-Horust supports more than one service directory by accepting more than one `--services-path` arguments.
+You can specify multiple service directories by passing more than one `--services-path` arguments.
 ```sh
-horust --services-path ./services/core --services-path ./services/extra
+horust --services-path ./services/core --services-path ./services/extra --services-path ./my-service.toml
 ```
-
 These directories are loaded at once and treated just like all `*.toml` files were in single shared directory.
 It means that for example service from `./services/extra` can depend on service from `./services/core`.
+The last parameter is used to load a single service file instead of a directory.
 
-## Plugins
-WIP. Horust works via message passing, so it should be fairly easy to have additional components connected to its bus.
-But I'm not sure at this time, if there is the need for this.
+## Plugins (WIP)
+Horust works via message passing, it should be fairly easy to plug additional components connected to its bus. 
+At this time is unclear if there is the need for this. Please raise an issue if you're interested in seeing this feature.
 
-## Checking system status
+## Checking system status (WIP)
 WIP: https://github.com/FedericoPonzi/Horust/issues/31
 The idea is to create another binary, which will somehow report the system status. A `systemctl` for Horust.

--- a/src/horust/formats/horust_config.rs
+++ b/src/horust/formats/horust_config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt, Serialize, Deserialize)]
+#[derive(Debug, StructOpt, Serialize, Deserialize, Default)]
 pub struct HorustConfig {
     #[structopt(long)]
     /// Exits with an unsuccessful exit code if any process is in FinishedFailed state
@@ -27,13 +27,5 @@ impl HorustConfig {
         Ok(HorustConfig {
             unsuccessful_exit_finished_failed,
         })
-    }
-}
-
-impl Default for HorustConfig {
-    fn default() -> Self {
-        Self {
-            unsuccessful_exit_finished_failed: false,
-        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     let mut horust = if !opts.command.is_empty() {
         info!("Running command: {:?}", opts.command);
         Horust::from_command(opts.command.into_iter().join(" "))
-    } else if !opts.services_paths.is_empty() {
+    } else {
         info!(
             "Loading services from {}",
             display_directories(&opts.services_paths)
@@ -67,8 +67,6 @@ fn main() -> Result<()> {
                 display_directories(&opts.services_paths)
             )
         })?
-    } else {
-        panic!("You need to specify either a path to a folder with services via --services-path or a command to run.");
     };
 
     if let ExitStatus::SomeServiceFailed = horust.run() {


### PR DESCRIPTION
Adds support to specifying a service file instead of a directory for the `--services-path` parameter.

### Motivation and Context
Fixes #106

### Description
Refactored the fetch_services() function to support specifying a file or a directory. I've also removed the list of service path from Horust struct (unused), we can readd them later if needed.

### How Has This Been Tested?
I've added a unit test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
