### PR TITLE
Fixes wrong documentation about start-after

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -34,15 +34,15 @@ stderr = "${HOME}${HORUST_LOGDIR}/stderr"
 # name = "myname"
 command = "/bin/bash -c 'echo hello world'"
 start-delay = "2s"
-start-after = ["another.toml", "second.toml"]
+start-after = ["database", "backend.toml"]
 stdout = "STDOUT"
 stderr = "/var/logs/hello_world_svc/stderr.log"
 user = "${USER}"
 working-directory = "/tmp/"
 ```
-* **`name` = `string`**: Name of the service. Optional, uses the filename by default.
+* **`name` = `string`**: Name of the service. If missing, Horust will use the filename by default.
 * **`command` = `string`**: Specify a command to run, or a full path. You can also add arguments. If a full path is not provided, the binary will be searched using the $PATH env variable.
-* **`start-after` = `[list<ServiceName>`**: Start after these other services. User their filename (e.g. `first.toml`).
+* **`start-after` = `list<ServiceName>`**: Start after these other services.
 If service `a` should start after service `b`, then `a` will be started as soon as `b` is considered Running or Finished. 
 If `b` goes in a `FinishedFailed` state (finished in an unsuccessful manner), `a` might not start at all. 
 * **`start-delay` = `time`**: Start this service with the specified delay. Check how to specify times [here](https://github.com/tailhook/humantime/blob/49f11fdc2a59746085d2457cb46bce204dec746a/src/duration.rs#L338) 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Check out the [documentation](https://github.com/FedericoPonzi/Horust/blob/maste
 ```toml
 command = "/bin/bash -c 'echo hello world'"
 start-delay = "2s"
-start-after = ["another.toml", "second.toml"]
+start-after = ["database", "backend.toml"]
 stdout = "STDOUT"
 stderr = "/var/logs/hello_world_svc/stderr.log"
 user = "root"

--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 pub fn get_sample_service() -> String {
     r#"command = "/bin/bash -c 'echo hello world'"
 start-delay = "2s"
-start-after = ["another.toml", "second.toml"]
+start-after = ["database", "backend.toml"]
 stdout = "STDOUT"
 stderr = "/var/logs/hello_world_svc/stderr.log"
 user = "${USER}"
@@ -729,7 +729,7 @@ mod test {
             stdout: "STDOUT".into(),
             stderr: "/var/logs/hello_world_svc/stderr.log".into(),
             start_delay: Duration::from_secs(2),
-            start_after: vec!["another.toml".into(), "second.toml".into()],
+            start_after: vec!["database".into(), "backend.toml".into()],
             restart: Restart {
                 strategy: RestartStrategy::Never,
                 backoff: Duration::from_millis(0),


### PR DESCRIPTION
The documentation was suggesting to use the filename instead of the
service name but instead service names should be used.

Horust will use service's filename as service name if it's not
specified in the toml file.

### Motivation and Context
Fixes #90

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
