### PR TITLE
Replace structopt with clap, and minor updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -100,17 +91,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -360,12 +375,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -382,6 +394,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "clap",
  "crossbeam",
  "env_logger",
  "humantime-serde",
@@ -396,7 +409,6 @@ dependencies = [
  "serde",
  "shellexpand",
  "shlex",
- "structopt",
  "tempdir",
  "thiserror",
  "toml",
@@ -541,9 +553,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "log"
@@ -611,14 +623,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
+ "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -657,9 +671,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "percent-encoding"
@@ -997,33 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1063,12 +1059,9 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -1191,18 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,16 +1202,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,18 @@ homepage = "https://github.com/FedericoPonzi/horust"
 readme = "README.md"
 keywords = ["init", "container", "supervisor"]
 categories = ["command-line-utilities"]
-include = [ "src/**/*", "Cargo.*", "LICENSE.txt", "README.md", ]
+include = ["src/**/*", "Cargo.*", "LICENSE.txt", "README.md", ]
 
 [dependencies]
-structopt = "~0.3"
-# Still not released: clap = { git = "https://github.com/clap-rs/clap/", rev = "28c46b5", version = "3.0.0-beta.1" }
+clap = { version = "~3.2", features = ["derive"] }
 crossbeam = "~0.8"
 env_logger = "~0.9"
 humantime-serde = "~1.1"
 libc = "~0.2"
 log = "~0.4"
-nix = "~0.24"
+nix = "~0.25"
 reqwest = { version = "~0.11", features = ["blocking", "json"], optional = true, default-features = false }
-serde = {version = "~1.0", features = ["derive"] }
+serde = { version = "~1.0", features = ["derive"] }
 shlex = "~1.1"
 toml = "~0.5"
 maplit = "~1.0"

--- a/src/horust/formats/horust_config.rs
+++ b/src/horust/formats/horust_config.rs
@@ -2,14 +2,13 @@ use std::path::Path;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use structopt::StructOpt;
 
 // TODO: this should be an optional
 // otherwise we wouldn't know if it was set to false on the commandline. Maybe. Because it's a flag.
 
-#[derive(Debug, StructOpt, Serialize, Deserialize, Default)]
+#[derive(Debug, clap::Parser, Serialize, Deserialize, Default)]
 pub struct HorustConfig {
-    #[structopt(long)]
+    #[clap(long)]
     /// Exits with an unsuccessful exit code if any process is in FinishedFailed state
     pub unsuccessful_exit_finished_failed: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use itertools::Itertools;
-use log::{error, info};
-use structopt::StructOpt;
-
+use clap::Parser;
 use horust::horust::ExitStatus;
 use horust::horust::HorustConfig;
 use horust::Horust;
+use itertools::Itertools;
+use log::{error, info};
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Parser, Debug)]
 #[structopt(author, about)]
 /// Horust is a complete supervisor and init system, designed for running in containers.
 struct Opts {
@@ -40,7 +39,7 @@ fn main() -> Result<()> {
         .write_style("HORUST_LOG_STYLE");
     env_logger::init_from_env(env);
 
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     if opts.sample_service {
         println!("{}", horust::get_sample_service());

--- a/tests/section_healthiness.rs
+++ b/tests/section_healthiness.rs
@@ -13,7 +13,7 @@ fn handle_requests(listener: TcpListener, stop: Receiver<()>) -> std::io::Result
         match stream {
             Ok(mut stream) => {
                 let mut buffer = [0; 512];
-                stream.read(&mut buffer).unwrap();
+                stream.read(&mut buffer)?;
                 let response = b"HTTP/1.1 200 OK\r\n\r\n";
                 stream.write_all(response).expect("Stream write");
             }

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -42,7 +42,7 @@ attempts = {}
         Some(service.as_str()),
         None,
     );
-    let mut cmd = cmd.args(vec!["--unsuccessful-exit-finished-failed"]);
+    let cmd = cmd.args(vec!["--unsuccessful-exit-finished-failed"]);
     let recv = run_async(cmd, should_contain);
     recv.recv_or_kill(Duration::from_secs(15));
 }
@@ -79,7 +79,7 @@ strategy = "on-failure"
         Some(service.as_str()),
         None,
     );
-    let mut cmd = cmd.args(vec!["--unsuccessful-exit-finished-failed"]);
+    let cmd = cmd.args(vec!["--unsuccessful-exit-finished-failed"]);
     let recv = run_async(cmd, true);
     recv.recv_or_kill(Duration::from_secs(15));
 }

--- a/tests/section_termination.rs
+++ b/tests/section_termination.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use nix::sys::signal::{kill, Signal};
 use std::time::Duration;
 

--- a/tests/service_deserialization.rs
+++ b/tests/service_deserialization.rs
@@ -1,7 +1,6 @@
-use horust::Horust;
 use std::path::PathBuf;
 
-pub fn list_files<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Vec<std::path::PathBuf>> {
+pub fn list_files<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Vec<PathBuf>> {
     let mut paths = std::fs::read_dir(path)?;
     paths.try_fold(vec![], |mut ret, p| match p {
         Ok(entry) => {
@@ -12,12 +11,21 @@ pub fn list_files<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Vec<std
     })
 }
 
-#[test]
-fn should_deserialize() {
-    // TODO: this shouldn't be an integration test, but rather a unit test.
-    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let services_path = base.join("example_services");
-    let services = list_files(&services_path).unwrap().len();
-    let horust = Horust::from_services_dir(&services_path).unwrap();
-    assert_eq!(horust.get_services().len(), services);
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use horust::Horust;
+
+    use crate::list_files;
+
+    #[test]
+    fn should_deserialize() {
+        // TODO: this shouldn't be an integration test, but rather a unit test.
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let services_path = base.join("example_services");
+        let services = list_files(&services_path).unwrap().len();
+        let horust = Horust::from_services_dirs(&[services_path]).unwrap();
+        assert_eq!(horust.get_services().len(), services);
+    }
 }


### PR DESCRIPTION
Structopt is in maintainance mode as clap 3 was finally released. As some of the packages used by structopt are also unmantained, this commit updates this dependency.

I've also bumped up a few more dependencies, and applied some new clippy lints on the code.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
