### PR TITLE
Compilation fixes for macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ aarch64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, i686-unknown-linux-gnu, i686-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl]
+        target:
+          - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-gnu
+          - i686-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-apple-darwin
+          - i686-apple-darwin
+          - x86_64-apple-darwin
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## Status
 At this point, this should be considered Alpha software. As in, you can (and should) use it, but under your own discretion.
+Horust can be used on macOS in development situations.  Due to limitations in the macOS API, subprocesses of supervised processes may not correctly be reaped when their parent process exits.
 
 ## Usage
 Assume you'd like to create a website health monitoring system. You can create one using Horust and a small python script.

--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -548,6 +548,7 @@ pub enum TerminationSignal {
     ALRM,
     #[default]
     TERM,
+    #[cfg(target_os = "linux")]
     STKFLT,
     CHLD,
     CONT,
@@ -562,6 +563,7 @@ pub enum TerminationSignal {
     PROF,
     WINCH,
     IO,
+    #[cfg(target_os = "linux")]
     PWR,
     SYS,
 }
@@ -584,6 +586,7 @@ impl From<TerminationSignal> for Signal {
             TerminationSignal::PIPE => SIGPIPE,
             TerminationSignal::ALRM => SIGALRM,
             TerminationSignal::TERM => SIGTERM,
+            #[cfg(target_os = "linux")]
             TerminationSignal::STKFLT => SIGSTKFLT,
             TerminationSignal::CHLD => SIGCHLD,
             TerminationSignal::CONT => SIGCONT,
@@ -598,6 +601,7 @@ impl From<TerminationSignal> for Signal {
             TerminationSignal::PROF => SIGPROF,
             TerminationSignal::WINCH => SIGWINCH,
             TerminationSignal::IO => SIGIO,
+            #[cfg(target_os = "linux")]
             TerminationSignal::PWR => SIGPWR,
             TerminationSignal::SYS => SIGSYS,
         }

--- a/src/horust/mod.rs
+++ b/src/horust/mod.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+#[cfg(target_os = "linux")]
 use libc::{prctl, PR_SET_CHILD_SUBREAPER};
 
 pub use formats::Event;
@@ -56,6 +57,7 @@ impl Horust {
 
     /// Blocking call, will setup the event loop and the threads and run all the available services.
     pub fn run(&mut self) -> ExitStatus {
+        #[cfg(target_os = "linux")]
         unsafe {
             // A subreaper fulfills the role of init(1) for its
             // descendant processes.  When a process becomes orphaned

--- a/src/horust/supervisor/process_spawner.rs
+++ b/src/horust/supervisor/process_spawner.rs
@@ -188,6 +188,9 @@ fn exec(
     unistd::setsid()?;
     // Set the user ID
     unistd::setuid(uid)?;
+    #[cfg(target_os = "linux")]
     unistd::execvpe(program_name.as_ref(), arg_cptr.as_ref(), env_cptr.as_ref())?;
+    #[cfg(not(target_os = "linux"))]
+    unistd::execve(program_name.as_ref(), arg_cptr.as_ref(), env_cptr.as_ref())?;
     Ok(())
 }

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -1,13 +1,11 @@
 use std::time::Duration;
 
 use assert_cmd::cmd::Command;
-use libc::{
-    c_int, SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF,
-    SIGQUIT, SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
-};
 #[cfg(target_os = "linux")]
+use libc::SIGPOLL;
 use libc::{
-    SIGPOLL
+    c_int, SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF, SIGQUIT,
+    SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
 };
 use predicates::prelude::predicate;
 use utils::*;
@@ -130,8 +128,8 @@ fn test_restart_always_killed_by_signals() -> Result<(), std::io::Error> {
     ];
     #[cfg(not(target_os = "linux"))]
     const DEFAULT_TERMINATE: [c_int; 19] = [
-        SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF,
-        SIGQUIT, SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
+        SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF, SIGQUIT,
+        SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
     ];
     for sig in DEFAULT_TERMINATE {
         test_restart_always_signal(sig as i32)?;

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -2,8 +2,12 @@ use std::time::Duration;
 
 use assert_cmd::cmd::Command;
 use libc::{
-    c_int, SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPOLL, SIGPROF,
+    c_int, SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF,
     SIGQUIT, SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
+};
+#[cfg(target_os = "linux")]
+use libc::{
+    SIGPOLL
 };
 use predicates::prelude::predicate;
 use utils::*;
@@ -119,8 +123,14 @@ strategy = "always"
 
 #[test]
 fn test_restart_always_killed_by_signals() -> Result<(), std::io::Error> {
+    #[cfg(target_os = "linux")]
     const DEFAULT_TERMINATE: [c_int; 20] = [
         SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPOLL, SIGPROF,
+        SIGQUIT, SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
+    ];
+    #[cfg(not(target_os = "linux"))]
+    const DEFAULT_TERMINATE: [c_int; 19] = [
+        SIGABRT, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE, SIGPROF,
         SIGQUIT, SIGSEGV, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGVTALRM, SIGXCPU, SIGXFSZ,
     ];
     for sig in DEFAULT_TERMINATE {

--- a/tests/section_termination.rs
+++ b/tests/section_termination.rs
@@ -83,18 +83,16 @@ fn test_termination_all_custom_signals() {
     #[cfg(target_os = "linux")]
     let signals = vec![
         "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE", "USR1", "SEGV", "USR2", "PIPE",
-        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU",
-        "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "SYS",
+        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU", "XFSZ",
+        "VTALRM", "PROF", "WINCH", "IO", "SYS",
     ];
     #[cfg(not(target_os = "linux"))]
     let signals = vec![
         "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE", "USR1", "SEGV", "USR2", "PIPE",
-        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU",
-        "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "SYS",
+        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU", "XFSZ",
+        "VTALRM", "PROF", "WINCH", "IO", "SYS",
     ];
-    signals
-    .into_iter()
-    .for_each(|friendly_name| {
+    signals.into_iter().for_each(|friendly_name| {
         eprintln!("Testing: {}", friendly_name);
         test_termination_custom_signal(friendly_name);
     })

--- a/tests/section_termination.rs
+++ b/tests/section_termination.rs
@@ -80,11 +80,19 @@ wait = "10s""#,
 /// User can set a custom termination signal, this test will ensure we're sending the correct one.
 #[test]
 fn test_termination_all_custom_signals() {
-    vec![
+    #[cfg(target_os = "linux")]
+    let signals = vec![
         "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE", "USR1", "SEGV", "USR2", "PIPE",
-        "ALRM", "TERM", "STKFLT", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU",
-        "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "PWR", "SYS",
-    ]
+        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU",
+        "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "SYS",
+    ];
+    #[cfg(not(target_os = "linux"))]
+    let signals = vec![
+        "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE", "USR1", "SEGV", "USR2", "PIPE",
+        "ALRM", "TERM", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU",
+        "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "SYS",
+    ];
+    signals
     .into_iter()
     .for_each(|friendly_name| {
         eprintln!("Testing: {}", friendly_name);


### PR DESCRIPTION
### Motivation and Context

We're evaluating Horust as process supervisor for a multi-service application.  While most of our deployments are container based, many of our developers work with macOS and local compilation.

### Description

When compiling for macOS, skip Linux specific calls and signals.  In particular, the sub-reaper functionality is not available on macOS, which could cause issues in situations where a process controlled by Horust dies and leaves behind children.  For development purposes, however, this does not seem to be a major issue.

See #37 for a previous conversation on the topic.

### How Has This Been Tested?

All tests pass on macOS Ventura 13.5.2 / Apple Silicon

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
