### PR TITLE
search command in PATH instead of relying on execvpe()

### DIFF
--- a/tests/horust.rs
+++ b/tests/horust.rs
@@ -20,7 +20,7 @@ fn test_config_unsuccessful_exit_finished_failed() {
     let failing_script = r#"#!/usr/bin/env bash
 exit 1
 "#;
-    store_service(temp_dir.path(), failing_script, None, None);
+    store_service_script(temp_dir.path(), failing_script, None, None);
     let recv = run_async(&mut cmd, true);
     recv.recv_or_kill(Duration::from_secs(15));
     let cmd = cmd.args(vec!["--unsuccessful-exit-finished-failed"]);
@@ -82,14 +82,14 @@ fn test_multiple() {
         } else {
             temp_dir_2.path()
         };
-        store_service(
+        store_service_script(
             t_dir,
             script,
             Some(service.as_str()),
             Some(i.to_string().as_str()),
         );
     }
-    store_service(temp_dir.path(), script, None, Some("0"));
+    store_service_script(temp_dir.path(), script, None, Some("0"));
     let recv = run_async(&mut cmd, true);
     recv.recv_or_kill(Duration::from_secs(max * 2));
 }
@@ -104,14 +104,14 @@ fn test_stress_test_chained_services() {
 
     for i in 1..max {
         let service = format!(r#"start-after = ["{}.toml"]"#, i - 1);
-        store_service(
+        store_service_script(
             temp_dir.path(),
             script,
             Some(service.as_str()),
             Some(i.to_string().as_str()),
         );
     }
-    store_service(temp_dir.path(), script, None, Some("0"));
+    store_service_script(temp_dir.path(), script, None, Some("0"));
     let recv = run_async(&mut cmd, true);
     recv.recv_or_kill(Duration::from_secs(max * 2));
 }

--- a/tests/section_environment.rs
+++ b/tests/section_environment.rs
@@ -4,7 +4,7 @@ use predicates::str::contains;
 
 #[allow(dead_code)]
 mod utils;
-use utils::{get_cli, store_service};
+use utils::{get_cli, store_service_script};
 
 static ENVIRONMENT_SCRIPT: &str = r#"#!/usr/bin/env bash
 printenv"#;
@@ -14,7 +14,7 @@ printenv"#;
 fn test_environment_additional() {
     let (mut cmd, temp_dir) = get_cli();
 
-    store_service(temp_dir.path(), ENVIRONMENT_SCRIPT, None, None);
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, None, None);
     cmd.assert().success().stdout(contains("bar").not());
 
     let service = r#"[environment]
@@ -23,7 +23,7 @@ re-export = [ "TERM" ]
 additional = { TERM = "bar" }
 "#;
     // Additional should overwrite TERM
-    store_service(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
     cmd.assert().success().stdout(contains("bar"));
 }
 
@@ -34,7 +34,7 @@ fn test_environment_keep_env() {
     let service = r#"[environment]
 keep-env = true
 "#;
-    store_service(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
     cmd.env("DB_PASS", "MyPassword")
         .assert()
         .success()
@@ -49,7 +49,7 @@ fn test_environment_re_export() {
 keep-env = false
 re-export = [ "DB_PASS" ]
 "#;
-    store_service(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
     cmd.env("DB_PASS", "MyPassword")
         .assert()
         .success()

--- a/tests/section_failure.rs
+++ b/tests/section_failure.rs
@@ -17,7 +17,7 @@ strategy = "{}"
 # Let's give horust some time to spinup the other service as well.
 sleep 1
 exit 1"#;
-    store_service(
+    store_service_script(
         temp_dir.path(),
         failing_script,
         Some(failing_service.as_str()),
@@ -32,7 +32,7 @@ wait = "500millis"
 sleep 30"#;
 
     //store_service(temp_dir.path(), sleep_script, None, None);
-    store_service(temp_dir.path(), sleep_script, Some(sleep_service), None);
+    store_service_script(temp_dir.path(), sleep_script, Some(sleep_service), None);
     let recv = run_async(&mut cmd, true);
     recv.recv_or_kill(Duration::from_secs(15));
 }

--- a/tests/section_general.rs
+++ b/tests/section_general.rs
@@ -60,9 +60,9 @@ fn test_output_redirection() {
 fn test_search_path_not_found() {
     let (mut cmd, temp_dir) = get_cli();
     store_service(temp_dir.path(), "command = \"non-existent-command\"", None);
-    cmd.assert()
-        .success()
-        .stderr(contains("Program not found in any of the PATH directories"));
+    cmd.assert().success().stderr(contains(
+        "Program \"non-existent-command\" not found in any of the PATH directories",
+    ));
 }
 
 #[test]

--- a/tests/section_healthiness.rs
+++ b/tests/section_healthiness.rs
@@ -50,7 +50,7 @@ http-endpoint = "{}""#,
     let script = r#"#!/usr/bin/env bash
     sleep 2
     "#;
-    store_service(tempdir.path(), script, Some(service.as_str()), None);
+    store_service_script(tempdir.path(), script, Some(service.as_str()), None);
     let (sender, receiver) = mpsc::sync_channel(0);
     let (stop_listener, sl_receiver) = mpsc::sync_channel(1);
 

--- a/tests/section_restart.rs
+++ b/tests/section_restart.rs
@@ -38,7 +38,7 @@ attempts = {}
             .display(),
         attempts
     );
-    store_service(
+    store_service_script(
         temp_dir.path(),
         failing_once_script.as_str(),
         Some(service.as_str()),
@@ -75,7 +75,7 @@ attempts = 0
 strategy = "on-failure"
 "#
     .to_string();
-    store_service(
+    store_service_script(
         temp_dir.path(),
         failing_once_script.as_str(),
         Some(service.as_str()),
@@ -103,7 +103,7 @@ kill -{} $$
 [restart]
 strategy = "always"
 "#;
-    store_service(
+    store_service_script(
         temp_dir.path(),
         suicide_script.as_str(),
         Some(service),
@@ -150,7 +150,7 @@ sleep 0.5
 [restart]
 strategy = "always"
 "#;
-    store_service(temp_dir.path(), suicide_script, Some(service), None);
+    store_service_script(temp_dir.path(), suicide_script, Some(service), None);
     cmd.timeout(Duration::from_millis(2000))
         .assert()
         .failure()

--- a/tests/section_termination.rs
+++ b/tests/section_termination.rs
@@ -29,7 +29,7 @@ done
 "#;
     let service = r#"[termination]
 wait = "1s""#;
-    store_service(temp_dir.path(), script, Some(service), None);
+    store_service_script(temp_dir.path(), script, Some(service), None);
 
     let recv = run_async(&mut cmd, true);
     kill(recv.pid, Signal::SIGINT).expect("kill");
@@ -66,7 +66,7 @@ wait = "10s""#,
         friendly_name
     ); // wait is higher than the test duration.
 
-    store_service(
+    store_service_script(
         temp_dir.path(),
         script.as_str(),
         Some(service.as_str()),
@@ -110,12 +110,12 @@ done
 wait = "0s"
 die-if-failed = ["a.toml"]"#;
 
-    store_service(temp_dir.path(), script, Some(service), None);
+    store_service_script(temp_dir.path(), script, Some(service), None);
     let script = r#"#!/usr/bin/env bash
 sleep 1
 exit 1
 "#;
-    store_service(temp_dir.path(), script, None, Some("a"));
+    store_service_script(temp_dir.path(), script, None, Some("a"));
     let recv = run_async(&mut cmd, true);
     recv.recv_or_kill(Duration::from_secs(10));
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -10,20 +10,35 @@ use std::thread;
 use std::time::Duration;
 use tempdir::TempDir;
 
+/// Create a random name
+pub fn create_random_name() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(5)
+        .map(|x| x as char)
+        .collect::<String>()
+}
+
+/// Stores a service
+pub fn store_service(dir: &Path, service: &str, service_name: Option<&str>) -> String {
+    let service_name = match service_name {
+        Some(name) => name.to_string(),
+        None => format!("{}.toml", create_random_name()),
+    };
+    std::fs::write(dir.join(&service_name), service).unwrap();
+    service_name
+}
+
 /// Creates script and service file, and stores them in dir.
 /// It will append a `command` at the top of the service, with a reference to script.
 /// Returns the service name.
-pub fn store_service(
+pub fn store_service_script(
     dir: &Path,
     script: &str,
     service: Option<&str>,
     service_name: Option<&str>,
 ) -> String {
-    let rnd_name = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(5)
-        .map(|x| x as char)
-        .collect::<String>();
+    let rnd_name = create_random_name();
     let service_name = format!("{}.toml", service_name.unwrap_or(rnd_name.as_str()));
     let script_name = format!("{}.sh", rnd_name);
     let script_path = dir.join(script_name);
@@ -34,8 +49,7 @@ pub fn store_service(
         script_path.display(),
         service.unwrap_or("")
     );
-    std::fs::write(dir.join(&service_name), service).unwrap();
-    service_name
+    store_service(dir, &service, Some(&service_name))
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
### Motivation and Context

execvpe() is not available on macOS

### Description

As execvpe() is not available on macOS, implement the PATH search in Rust so that things work on both platforms

### How Has This Been Tested?

All tests pass

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
