### PR TITLE
Default service working directory to horust's working directory

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -49,7 +49,7 @@ If `b` goes in a `FinishedFailed` state (finished in an unsuccessful manner), `a
 * **`stdout` = `STDOUT|STDERR|file-path`**: Redirect stdout of this service. STDOUT and STDERR are special strings, pointing to stdout and stderr respectively. Otherwise, a file path is assumed.
 * **`stderr` = `STDOUT|STDERR|file-path`**: Redirect stderr of this service. Read `stdout` above for a complete reference.
 * **`user` = `uid|username`**: Will run this service as this user. Either an uid or a username (check it in /etc/passwd)
-* **`working-directory` = `string`**: Will run this command in this directory.
+* **`working-directory` = `string`**: Will run this command in this directory.  Defaults to the working directory of the horust process.
 
 #### Restart section
 ```toml

--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::env;
 use std::ffi::OsStr;
 use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
@@ -54,7 +55,7 @@ pub struct Service {
 
 impl Service {
     fn default_working_directory() -> PathBuf {
-        PathBuf::from("/")
+        env::current_dir().unwrap()
     }
 
     fn default_stdout_log() -> LogOutput {
@@ -101,7 +102,7 @@ impl Default for Service {
         Self {
             name: "".to_owned(),
             start_after: Default::default(),
-            working_directory: "/".into(),
+            working_directory: env::current_dir().unwrap(),
             stdout: Default::default(),
             stderr: Default::default(),
             user: Default::default(),

--- a/tests/section_general.rs
+++ b/tests/section_general.rs
@@ -69,6 +69,17 @@ pwd"#;
 }
 
 #[test]
+fn test_cwd_default() {
+    let (mut cmd, temp_dir) = get_cli();
+    let script = r#"#!/usr/bin/env bash
+pwd"#;
+    store_service(temp_dir.path(), script, None, None);
+    cmd.assert()
+        .success()
+        .stdout(contains(&temp_dir.path().display().to_string()));
+}
+
+#[test]
 fn test_start_after() {
     let (mut cmd, temp_dir) = get_cli();
     let script_first = r#"#!/usr/bin/env bash


### PR DESCRIPTION
### Motivation and Context

When working in non-container environments, the default working directory "/" for services is not very useful. 

#210 

### Description

Change the default working directory to the working directory of the horust process.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
