### PR TITLE
Fixes #217

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horust"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Federico Ponzi <me@fponzi.me>"]
 description = "A complete supervisor and init system, designed for running in containers."
 edition = "2021"

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -121,8 +121,8 @@ keep-env = false
 re-export = [ "PATH", "DB_PASS"]
 additional = { key = "value"} 
 ```
-* **`keep-env` = `bool`**: default: true. Pass over all the environment variables.
-Regardless the value of keep-env, the following keys will be updated / defined:
+* **`keep-env` = `bool`**: default: false. Pass over all the environment variables.
+Regardless of the value of keep-env, the following keys will be updated / defined:
 * `USER`
 * `HOSTNAME`
 * `HOME`

--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -75,8 +75,8 @@ impl Service {
         P: AsRef<Path> + ?Sized + AsRef<OsStr> + Debug,
     {
         let preconfig = std::fs::read_to_string(path)?;
-        let postconfig = shellexpand::full(&preconfig)?.to_string();
-        toml::from_str::<Service>(&postconfig).map_err(Error::from)
+        let postconfig = shellexpand::full(&preconfig)?;
+        Ok(toml::from_str::<Service>(&postconfig)?)
     }
     /// Creates the environment K=V variables, used for exec into the new process.
     /// User defined environment variables overwrite the predefined values.
@@ -203,7 +203,7 @@ impl From<&str> for LogOutput {
 #[derive(Serialize, Clone, Default, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Environment {
-    #[serde(default = "Environment::default_keep_env")]
+    #[serde(default)]
     pub keep_env: bool,
     #[serde(default)]
     pub re_export: Vec<String>,
@@ -212,10 +212,6 @@ pub struct Environment {
 }
 
 impl Environment {
-    fn default_keep_env() -> bool {
-        true
-    }
-
     fn get_hostname_val() -> String {
         let hostname_path = "/etc/hostname";
         let localhost = "localhost".to_string();

--- a/tests/section_environment.rs
+++ b/tests/section_environment.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use predicates::str::contains;
+use std::env::temp_dir;
 
 #[allow(dead_code)]
 mod utils;
@@ -28,17 +29,38 @@ additional = { TERM = "bar" }
 }
 
 #[test]
-fn test_environment_keep_env() {
+fn test_environment_keep_env_absent() {
     let (mut cmd, temp_dir) = get_cli();
-    // keep-env should keep the env :D
+    // By default, keep-env is false
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(""), None);
+    cmd.env("DB_PASS", "MyPassword")
+        .assert()
+        .success()
+        .stdout(contains("MyPassword").not());
+}
+#[test]
+fn test_environment_keep_env_true() {
+    let (mut cmd, temp_dir) = get_cli();
     let service = r#"[environment]
-keep-env = true
-"#;
+    keep-env = true
+    "#;
     store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
     cmd.env("DB_PASS", "MyPassword")
         .assert()
         .success()
         .stdout(contains("MyPassword"));
+}
+#[test]
+fn test_environment_keep_env_false() {
+    let (mut cmd, temp_dir) = get_cli();
+    let service = r#"[environment]
+    keep-env = false
+    "#;
+    store_service_script(temp_dir.path(), ENVIRONMENT_SCRIPT, Some(service), None);
+    cmd.env("DB_PASS", "MyPassword")
+        .assert()
+        .success()
+        .stdout(contains("MyPassword").not());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #217 by switching keep-env to be default false.

### Description
When a struct is not defined at all in the config toml file, serde calls the Default implementation instead of using the '#serde(default)` annotations. This means that currently keep-env was a bit inconsistent:
* if environment section is not defined, keep-env was false (set by the rust's Default impl for booleans).
* if anything other than keep-env was defined, keep-env was set to true (set by serde's default impl we provided).
* else, keep-env's value was used if it was defined.
In this PR, I'm changing the default to be false (hopefully it will cause less breaking changes).


### How Has This Been Tested?
Added more tests cases.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
