### PR TITLE
Don't spawn a worker if there are no healthchecks to be done.

### DIFF
--- a/src/horust/formats/service.rs
+++ b/src/horust/formats/service.rs
@@ -290,12 +290,17 @@ pub struct Healthiness {
     pub http_endpoint: Option<String>,
     pub file_path: Option<PathBuf>,
     #[serde(default = "Healthiness::default_max_failed")]
+    // todo: use an u32
     pub max_failed: i32,
 }
 
 impl Healthiness {
     fn default_max_failed() -> i32 {
         3
+    }
+
+    pub(crate) fn has_any_check_defined(&self) -> bool {
+        self.http_endpoint.is_some() || self.file_path.is_some()
     }
 }
 

--- a/src/horust/healthcheck/checks.rs
+++ b/src/horust/healthcheck/checks.rs
@@ -5,11 +5,12 @@ use reqwest::blocking::Client;
 
 use crate::horust::formats::Healthiness;
 
-static FILE_CHECK: FilePathCheck = FilePathCheck {};
-static HTTP_CHECK: HttpCheck = HttpCheck {};
+const FILE_CHECK: FilePathCheck = FilePathCheck {};
+const HTTP_CHECK: HttpCheck = HttpCheck {};
+const CHECKS: [&dyn Check; 2] = [&FILE_CHECK, &HTTP_CHECK];
 
-pub(crate) fn get_checks() -> Vec<&'static dyn Check> {
-    vec![&FILE_CHECK, &HTTP_CHECK]
+pub(crate) fn get_checks() -> [&'static dyn Check; 2] {
+    CHECKS
 }
 
 pub(crate) trait Check {

--- a/src/horust/supervisor/mod.rs
+++ b/src/horust/supervisor/mod.rs
@@ -1,4 +1,4 @@
-//! The supervisor is one of the biggest module. It is responsible for supervising the services, and
+//! The supervisor is one of the biggest modules. It is responsible for supervising the services, and
 //! keeping track of their current state.
 //! It will also reap the dead processes
 

--- a/src/horust/supervisor/reaper.rs
+++ b/src/horust/supervisor/reaper.rs
@@ -13,7 +13,7 @@ use crate::horust::Event;
 ///
 /// # Safety
 ///
-/// This function must run in isolation with respect to the fork processes in order to
+/// This function must run in isolation with respect to the fork processes to
 /// prevent pid reusage.
 pub(crate) fn run(repo: &Repo, max_iterations: u32) -> Vec<Event> {
     (0..max_iterations)

--- a/src/horust/supervisor/service_handler.rs
+++ b/src/horust/supervisor/service_handler.rs
@@ -143,7 +143,7 @@ fn next_events(repo: &Repo, service_handler: &ServiceHandler) -> Vec<Event> {
         ServiceStatus::Initial if repo.is_service_runnable(service_handler) => {
             vec![Event::Run(service_handler.name().clone())]
         }
-        // if enough time have passed, this will be considered running
+        // if enough time has passed, this will be considered running
         ServiceStatus::Started if !service_handler.has_some_failed_healthchecks() => {
             vev_status(ServiceStatus::Running)
         }
@@ -227,8 +227,7 @@ fn handle_status_change(
     //TODO: refactor + cleanup.
     // A -> [B,C] means that transition to A is allowed only if service is in state B or C.
     let allowed_transitions = hashmap! {
-        ServiceStatus::Initial        => vec![ServiceStatus::Success, ServiceStatus::Failed,
-                                              ServiceStatus::Started],
+        ServiceStatus::Initial        => vec![ServiceStatus::Success, ServiceStatus::Failed],
         ServiceStatus::Starting       => vec![ServiceStatus::Initial],
         ServiceStatus::Started        => vec![ServiceStatus::Starting],
         ServiceStatus::InKilling      => vec![ServiceStatus::Initial,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Should fix the memory leak in healthcheck module. Solves #201 

### Description
My suspect is that any time Started event is received, a new Worker thread is spawned but it's currently missing a check to test if the worker already exist. In theory, this should not happen as we're removing the worker when service exits, but I feel there is still a possibility for it to get there. In any case, I've added a check to avoid spawning the worker thread altogether if there are no healthchecks defined.

An alternative would be to just exit early this healthcheck manager but it might get annoying later if we add a way to reload processes configurations.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Added more unit tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
