### PR TITLE
Allow chunking of stdout output files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytefmt"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590b1af059a21c47d4da7cd11f05e08b1992b58b5b4acf2a5e10d7e53aed3d74"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +464,7 @@ version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bytefmt",
  "clap",
  "crossbeam",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ maplit = "~1.0"
 shellexpand = "~3.1"
 anyhow = "~1.0"
 thiserror = "~1.0"
+bytefmt = "0.1.7"
 
 [features]
 default = ["http-healthcheck"]

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -47,6 +47,12 @@ If service `a` should start after service `b`, then `a` will be started as soon 
 If `b` goes in a `FinishedFailed` state (finished in an unsuccessful manner), `a` might not start at all. 
 * **`start-delay` = `time`**: Start this service with the specified delay. Check how to specify times [here](https://github.com/tailhook/humantime/blob/49f11fdc2a59746085d2457cb46bce204dec746a/src/duration.rs#L338) 
 * **`stdout` = `STDOUT|STDERR|file-path`**: Redirect stdout of this service. STDOUT and STDERR are special strings, pointing to stdout and stderr respectively. Otherwise, a file path is assumed.
+* **`stdout-rotate-size` = `string`**: Chunk size of the file specified in `stdout`.
+Once the file grows above the specified size it will be closed and a new file will be created with a suffix `.1`.
+Once the new file also grows above the specified size it will also be closed and a next one will be created with the next suffix `.2`.
+This allows adding external log rotation script, which can compress the old logs and maybe move them out to a different storage location.
+The size is parsed using `bytefmt` - for example `100 MB`, `200 KB`, `110 MIB` or `200 GIB`.
+If unset, the default value will be `100 MB`.
 * **`stderr` = `STDOUT|STDERR|file-path`**: Redirect stderr of this service. Read `stdout` above for a complete reference.
 * **`user` = `uid|username`**: Will run this service as this user. Either an uid or a username (check it in /etc/passwd)
 * **`working-directory` = `string`**: Will run this command in this directory.  Defaults to the working directory of the horust process.

--- a/example_services/sample_service.toml
+++ b/example_services/sample_service.toml
@@ -2,8 +2,9 @@
 command = "/bin/bash -c 'echo hello world'"
 start-delay = "2s"
 start-after = ["database", "backend.toml"]
-stdout = "STDOUT"
-stderr = "/var/logs/hello_world_svc/stderr.log"
+stdout = "/var/logs/hello_world_svc/stdout.log"
+stdout-rotate-size = "100 MB"
+stderr = "STDERR"
 # Check also `templating.toml`
 user = "${USER}"
 working-directory = "/tmp/"
@@ -25,7 +26,7 @@ max-failed = 3
 
 [failure]
 # by convention, zero conveys successful execution. Use this parameter to add more successfull exit codes.
-successful-exit-code = [ 0, 1, 255]
+successful-exit-code = [0, 1, 255]
 # Don't shut all the services down if this service fails.
 strategy = "ignore"
 
@@ -33,9 +34,9 @@ strategy = "ignore"
 # Regardless of this value, the programm will get `USER`, `HOSTNAME`, `HOME` and `PATH`.
 keep-env = false
 # Use for fine-grained re-exports.
-re-export = [ "PATH", "DB_PASS"]
+re-export = ["PATH", "DB_PASS"]
 # You can provide additional env variables using a map.
-additional = { key = "value"}
+additional = { key = "value" }
 
 [termination]
 # Signal to use for termination.
@@ -43,4 +44,5 @@ signal = "TERM"
 # Timeout before shutting the service down.
 wait = "10s"
 # If any of the services in the list has failed, shut down this service.
-die-if-failed  = [ "db.toml"]
+die-if-failed = ["db.toml"]
+

--- a/src/horust/supervisor/process_spawner.rs
+++ b/src/horust/supervisor/process_spawner.rs
@@ -61,7 +61,7 @@ pub(crate) fn spawn_fork_exec_handler(
 fn exec_args(service: &Service) -> Result<(CString, Vec<CString>, Vec<CString>)> {
     let chunks: Vec<String> =
         shlex::split(&service.command).context(format!("Invalid command: {}", service.command,))?;
-    let program_name = String::from(chunks.get(0).unwrap());
+    let program_name = String::from(chunks.first().unwrap());
     let to_cstring = |s: Vec<String>| {
         s.into_iter()
             .map(|arg| CString::new(arg).map_err(Into::into))
@@ -70,7 +70,7 @@ fn exec_args(service: &Service) -> Result<(CString, Vec<CString>, Vec<CString>)>
     let arg_cstrings = to_cstring(chunks)?;
     let environment = service.get_environment()?;
     let env_cstrings = to_cstring(environment)?;
-    let path = if program_name.contains("/") {
+    let path = if program_name.contains('/') {
         program_name.to_string()
     } else {
         find_program(&program_name)?

--- a/src/horust/supervisor/process_spawner.rs
+++ b/src/horust/supervisor/process_spawner.rs
@@ -1,9 +1,13 @@
 use std::ffi::{CStr, CString};
-use std::io;
-use std::ops::Add;
 use std::os::unix::io::AsRawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::{fs::File, io::BufReader};
+use std::{fs::OpenOptions, ops::Add};
+use std::{
+    io::{self, Read},
+    os::fd::OwnedFd,
+};
 
 use anyhow::{anyhow, Context, Result};
 use crossbeam::channel::{after, tick};
@@ -121,12 +125,33 @@ fn spawn_process(service: &Service) -> Result<Pid> {
     let cwd = service.working_directory.clone();
     let arg_cptr: Vec<&CStr> = arg_cstrings.iter().map(|c| c.as_c_str()).collect();
     let env_cptr: Vec<&CStr> = env_cstrings.iter().map(|c| c.as_c_str()).collect();
+    let mut service_copy = service.clone();
+    let (pipe_read, pipe_write) = if service.stdout_rotate_size > 0 {
+        let (pipe_read, pipe_write) = unistd::pipe()?;
+        (Some(pipe_read), Some(pipe_write))
+    } else {
+        (None, None)
+    };
     match unsafe { fork() } {
         Ok(ForkResult::Child) => {
-            child_process_main(service, path, cwd, uid, arg_cptr, env_cptr);
+            if let Some(pipe_write) = &pipe_write {
+                drop(pipe_read.unwrap());
+                service_copy.stdout = LogOutput::Pipe(pipe_write.as_raw_fd());
+            }
+            child_process_main(&service_copy, path, cwd, uid, arg_cptr, env_cptr);
             unreachable!();
+            // Here the "pipe_write" would go out of scope and its descriptor would be closed.
+            // But because child_process_main() does an exec() and never returns, the raw
+            // descriptor inside the LogOutput::Pipe stays open.
         }
         Ok(ForkResult::Parent { child, .. }) => {
+            pipe_read.and_then(|pipe| {
+                drop(pipe_write.unwrap());
+                std::thread::spawn(move || {
+                    chunked_writer(pipe, service_copy).map_err(|e| error!("{e}"))
+                });
+                None::<()>
+            });
             debug!("Spawned child with PID {}.", child);
             Ok(child)
         }
@@ -151,6 +176,12 @@ fn redirect_output(
             // Redirect stdout to stderr
             unistd::dup2(stderr, stdout)?;
         }
+        (LogOutput::Pipe(pipe), LogOutput::Stderr) => {
+            unistd::dup2(*pipe, stderr)?;
+        }
+        (LogOutput::Pipe(pipe), LogOutput::Stdout) => {
+            unistd::dup2(*pipe, stdout)?;
+        }
         (LogOutput::Path(path), LogOutput::Stdout) => {
             let raw_fd = fcntl::open(
                 path,
@@ -170,6 +201,38 @@ fn redirect_output(
         // Should never happen.
         _ => (),
     };
+    Ok(())
+}
+
+fn open_next_chunk(base_path: &Path) -> io::Result<File> {
+    let mut count = 1;
+    let mut path = base_path;
+    let mut path_str;
+
+    while path.is_file() {
+        path_str = format!("{}.{count}", base_path.to_string_lossy());
+        path = Path::new(&path_str);
+        count += 1;
+    }
+    debug!("Opening next log output: {}", path.display());
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+fn chunked_writer(fd: OwnedFd, service: Service) -> Result<()> {
+    let source = File::from(fd);
+    let path = match &service.stdout {
+        LogOutput::Path(path) => path,
+        _ => return Err(anyhow!("Log output path is not set")),
+    };
+    loop {
+        let mut reader = BufReader::new(&source).take(service.stdout_rotate_size);
+        let mut output = open_next_chunk(path)?;
+        let copied = io::copy(&mut reader, &mut output)?;
+        if copied < service.stdout_rotate_size {
+            debug!("EOF reached");
+            break;
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation and Context
When Horust runs for longer periods of time and the supervised programs generate a lot of output, it would be beneficial to introduce a simple log rotation system. A full-blown solution would have Horust have a complicated log rotation and compression system - but that would be an overkill. A much simpler (and chosen) approach is to just chunk the output file and then let the user customize the rotation with a small shell script.

### Description
This change adds a parameter `stdout-rotation-size` which allows setting the maximum size of the stdout output file in bytes. For example: if this is set to 10240 (10 kb) and the stdout is redirected to `/tmp/out.txt`, then as soon as this file grows to 10kb it will be closed and a new file `/tmp/out.txt.1` will be created and the output will continue there.
Having these separate output files allows compressing the, for example with gzip.

### How Has This Been Tested?
The changes are tightly bound to spawning threads, duping descriptors and creating files - so it is very hard to test them with unit tests. But they were tested with a simple configuration file:
```
command = "nfsstat -v -s -Z3"
stdout = "/tmp/foo-stdout.log"
stdout-rotate-size = 2048
working-directory = "/tmp/"
```
This correctly created a bunch of `/tmp/foo-stdout*` files after some time, each 2kb large.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
