### PR TITLE
Allow joining the internal Horust bus

### DIFF
--- a/horust/src/horust/bus.rs
+++ b/horust/src/horust/bus.rs
@@ -182,7 +182,7 @@ where
         self.receiver.try_iter().map(|m| m.into_payload()).collect()
     }
 
-    pub(crate) fn send_event(&self, ev: T) {
+    pub fn send_event(&self, ev: T) {
         self.state
             .sender
             .send(self.wrap(ev))

--- a/horust/src/horust/formats/mod.rs
+++ b/horust/src/horust/formats/mod.rs
@@ -35,7 +35,7 @@ impl Event {
     pub(crate) fn new_status_changed(service_name: &str, status: ServiceStatus) -> Self {
         Self::StatusChanged(service_name.to_string(), status)
     }
-    pub(crate) fn new_status_update(service_name: &str, status: ServiceStatus) -> Self {
+    pub fn new_status_update(service_name: &str, status: ServiceStatus) -> Self {
         Self::StatusUpdate(service_name.to_string(), status)
     }
     pub(crate) fn new_service_exited(service_name: ServiceName, exit_status: i32) -> Self {


### PR DESCRIPTION
### Motivation and Context
See #263 for previous discussion.
Also see https://github.com/raccoon-os/rccn_userspace_ws/blob/launch_service/src/rccn_usr_launch for how I am using this in my application.

### Description
I've made some function and modules public so that it we can use them as a library.

### How Has This Been Tested?
I ran `cargo test` and nothing broke. I also tested it in my application.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
