### PR TITLE
[DRAFT] service: add autostart option

### DIFF
--- a/horust/src/horust/formats/service.rs
+++ b/horust/src/horust/formats/service.rs
@@ -55,6 +55,8 @@ pub struct Service {
     pub environment: Environment,
     #[serde(default)]
     pub termination: Termination,
+    #[serde(default = "Service::default_autostart")]
+    pub autostart: bool,
 }
 
 fn default_as_false() -> bool {
@@ -72,6 +74,10 @@ impl Service {
 
     fn default_stderr_log() -> LogOutput {
         LogOutput::Stderr
+    }
+
+    fn default_autostart() -> bool {
+        true
     }
 
     /// Tries to load specific config from path.
@@ -124,6 +130,7 @@ impl Default for Service {
             environment: Default::default(),
             failure: Default::default(),
             termination: Default::default(),
+            autostart: true,
         }
     }
 }
@@ -695,6 +702,7 @@ mod test {
             name: "".to_string(),
             command: "/bin/bash -c \'echo hello world\'".to_string(),
             user: super::User::Name(current_user_name),
+            autostart: true,
             environment: Environment {
                 keep_env: false,
                 re_export: vec!["PATH".to_string(), "DB_PASS".to_string()],

--- a/horust/src/horust/supervisor/repo.rs
+++ b/horust/src/horust/supervisor/repo.rs
@@ -98,6 +98,10 @@ impl Repo {
         if !sh.is_initial() {
             return false;
         }
+        if !sh.service().autostart {
+            return false;
+        }
+
         let is_started = |service_name: &ServiceName| {
             let sh = self.services.get(service_name).unwrap();
             sh.is_running() || sh.is_finished()


### PR DESCRIPTION
### Motivation and Context
This PR adds an option to autostart services (set to true by default).
We need this in our application to designate services that should not be started by default, only by command.

### Description
The change is quite simple: `Repo::is_service_runnable()` now also checks if `service.autostart` is `true`, otherwise it doesn't start it.
I'm not sure that I like the the name `Repo::is_service_runnable()` (as the service is in fact runnable, but we choose not to run it), or the fact that the service stays in the `Initial` state when `autostart` is false and the service is not running.
Your thoughts would be welcome here.

### How Has This Been Tested?
Works on my computer :tm:
Let me know if you have some thoughts on how to test it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
