### PR TITLE
Bump base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM rust:1 as builder
+FROM rust:1 AS builder
 WORKDIR /usr/src/myapp
 COPY . .
 ARG CARGO_PARAMS
 ARG GIT_COMMIT
 ARG GIT_BRANCH
 ARG IMAGE_NAME
-RUN apt-get update && apt-get install -y protobuf-compiler 
+RUN apt-get update && apt-get install -y protobuf-compiler
 
 RUN echo "Running cargo build with params: $CARGO_PARAMS" && cargo build --release $CARGO_PARAMS
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 COPY --from=builder /usr/src/myapp/target/release/horust /sbin/horust
 RUN mkdir -p /etc/horust/services/ && apt-get update && apt-get install bash
 ENV HORUST_LOG info


### PR DESCRIPTION
### Motivation and Context
currently the docker image seems to be broken because of missing required minimal GLIBC version. 
```
/sbin/horust: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /sbin/horust)
/sbin/horust: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /sbin/horust)
/sbin/horust: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by /sbin/horust)
/sbin/horust: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /sbin/horust)
```

### Description
I've just bumped the base debian to the latest version

### How Has This Been Tested?
I've tested in the context of #273 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
