### PR TITLE
fix: bound on-failure restart attempts

### DIFF
--- a/horust/src/horust/supervisor/mod.rs
+++ b/horust/src/horust/supervisor/mod.rs
@@ -16,7 +16,9 @@ use service_handler::ServiceHandler;
 pub(crate) use signal_handling::init;
 
 use crate::horust::bus::BusConnector;
-use crate::horust::formats::{Event, ExitStatus, Service, ServiceStatus, ShuttingDown};
+use crate::horust::formats::{
+    Event, ExitStatus, RestartStrategy, Service, ServiceStatus, ShuttingDown,
+};
 use crate::horust::healthcheck;
 
 mod process_spawner;
@@ -133,10 +135,11 @@ impl Supervisor {
 
                 // If it has failed too quickly, increase service_handler's restart attempts
                 // and check if it has more attempts left.
-                service_handler.restart_attempts += u32::from(
-                    service_handler.has_some_failed_healthchecks()
-                        && service_handler.is_early_state(),
-                );
+                let counts_toward_restart_budget = (has_failed
+                    && service_handler.service().restart.strategy == RestartStrategy::OnFailure)
+                    || (service_handler.has_some_failed_healthchecks()
+                        && service_handler.is_early_state());
+                service_handler.restart_attempts += u32::from(counts_toward_restart_budget);
 
                 let new_status = if has_failed
                     || (service_handler.status == ServiceStatus::Running

--- a/horust/src/horust/supervisor/service_handler.rs
+++ b/horust/src/horust/supervisor/service_handler.rs
@@ -259,7 +259,7 @@ fn handle_status_change(
 
     if valid {
         match next_status {
-            Started => {
+            Started if service_handler.service.restart.strategy != RestartStrategy::OnFailure => {
                 new_service_handler.status = Started;
                 new_service_handler.restart_attempts = 0;
             }
@@ -304,6 +304,13 @@ fn handle_restart_strategy(service_handler: &ServiceHandler, is_failed: bool) ->
             } else {
                 ServiceStatus::Initial
             }
+        }
+        RestartStrategy::OnFailure
+            if is_failed
+                && service_handler.service.restart.attempts > 0
+                && service_handler.restart_attempts_are_over() =>
+        {
+            ServiceStatus::FinishedFailed
         }
         RestartStrategy::OnFailure if is_failed => ServiceStatus::Initial,
         RestartStrategy::Never | RestartStrategy::OnFailure => ServiceStatus::Finished,
@@ -405,6 +412,32 @@ strategy = "{}"
                 let received = handle_restart_strategy(&sh, has_failed);
                 assert_eq!(received, expected);
             });
+    }
+
+    #[test]
+    fn test_on_failure_exhausts_configured_restart_attempts() {
+        let service: Service = Service::from_str(
+            r#"name="servicename"
+command = "Not relevant"
+[restart]
+strategy = "on-failure"
+attempts = 3
+"#,
+        )
+        .unwrap();
+        let mut sh: ServiceHandler = service.into();
+
+        sh.restart_attempts = 3;
+        assert_eq!(
+            handle_restart_strategy(&sh, true),
+            Event::new_status_update("servicename", ServiceStatus::Initial)
+        );
+
+        sh.restart_attempts = 4;
+        assert_eq!(
+            handle_restart_strategy(&sh, true),
+            Event::new_status_update("servicename", ServiceStatus::FinishedFailed)
+        );
     }
 
     #[test]
@@ -564,8 +597,19 @@ wait = "10s"
     }
 
     #[test]
-    fn test_started_transition_resets_restart_attempts() {
+    fn test_started_transition_preserves_restart_attempts() {
         let mut sh = make_handler("svc", ServiceStatus::Starting);
+        sh.service.restart.strategy = RestartStrategy::OnFailure;
+        sh.restart_attempts = 5;
+        let (new_sh, new_status) = sh.change_status(ServiceStatus::Started);
+        assert_eq!(new_status, ServiceStatus::Started);
+        assert_eq!(new_sh.restart_attempts, 5);
+    }
+
+    #[test]
+    fn test_started_transition_resets_attempts_for_other_strategies() {
+        let mut sh = make_handler("svc", ServiceStatus::Starting);
+        sh.service.restart.strategy = RestartStrategy::Always;
         sh.restart_attempts = 5;
         let (new_sh, new_status) = sh.change_status(ServiceStatus::Started);
         assert_eq!(new_status, ServiceStatus::Started);
@@ -573,7 +617,7 @@ wait = "10s"
     }
 
     #[test]
-    fn test_non_started_transition_preserves_restart_attempts() {
+    fn test_running_transition_preserves_restart_attempts() {
         let mut sh = make_handler("svc", ServiceStatus::Started);
         sh.restart_attempts = 3;
         let (new_sh, _) = sh.change_status(ServiceStatus::Running);

--- a/horust/tests/section_restart.rs
+++ b/horust/tests/section_restart.rs
@@ -86,6 +86,58 @@ strategy = "on-failure"
     recv.recv_or_kill(Duration::from_secs(15));
 }
 
+#[test]
+fn test_restart_strategy_on_failure_exhausts_attempts() {
+    let (cmd, temp_dir) = get_cli();
+    let attempts_log = temp_dir.path().join("attempts.log");
+    let always_failing_script = format!(
+        r#"#!/usr/bin/env bash
+printf 'run\n' >> "{}"
+exit 1
+"#,
+        attempts_log.display()
+    );
+    let service = r#"
+[restart]
+attempts = 3
+backoff = "1ms"
+strategy = "on-failure"
+
+[failure]
+successful-exit-code = [0]
+strategy = "ignore"
+"#;
+    store_service_script(temp_dir.path(), &always_failing_script, Some(service), None);
+
+    let mut cmd = cmd;
+    let mut child = cmd
+        .arg("--unsuccessful-exit-finished-failed")
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            let launches = std::fs::read_to_string(&attempts_log)
+                .map(|contents| contents.lines().count())
+                .unwrap_or(0);
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("Horust did not stop after {launches} launches");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    assert_eq!(status.code(), Some(101));
+
+    let launches = std::fs::read_to_string(attempts_log)
+        .unwrap()
+        .lines()
+        .count();
+    assert_eq!(launches, 4, "initial launch plus three retries");
+}
+
 /// With restart strategy set to always, the child service should be always restarted regardless of
 /// the reason why it exited.
 fn test_restart_always_signal(signal: i32) -> Result<(), std::io::Error> {


### PR DESCRIPTION
Fixes #318.

## Summary

- count every unsuccessful `on-failure` exit toward a positive configured restart budget
- preserve `attempts = 0` as the existing unbounded default
- stop resetting `on-failure` attempts during `Started` transitions while preserving reset behavior for other strategies
- transition to `FinishedFailed` after the configured retries are exhausted

With `attempts = 3`, Horust now performs the initial launch plus three retries, then exits with its documented failed-service status instead of continuing indefinitely.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p horust` (all unit and integration sections passed; one existing ignored test)
- `cargo test -p horust --test section_restart` (5 passed)
- `cargo clippy -p horust --lib --bins`

The repository-wide all-target clippy command still reports pre-existing `unused_io_amount` findings in healthcheck test code and an existing dead-code warning in `tests/utils`; this patch does not touch those surfaces.
