### PR TITLE
fix: bound restart attempts across all strategies (#318)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,17 +111,23 @@ attempts = 0
 
 * **`strategy` = `always|on-failure|never`**: Defines the restart strategy.
 
-    * `always`: Failure or Success, it will be always restarted
-    * `on-failure`: Only if it has failed. Please check the `attempts` parameter below.
-    * `never`: It won't be restarted, no matter what's the exit status. Please check the `attempts` parameter below.
+    * `always`: Failure or Success, it will always be restarted (bounded by `attempts`, see below).
+    * `on-failure`: Only if it has failed (bounded by `attempts`, see below).
+    * `never`: By default it won't be restarted, no matter the exit status. It may still be restarted as a
+      rapid-failure escape hatch if `attempts` is configured (see below).
 
 * **`backoff` = `string`**: Use this time before retrying restarting the service.
-* **`attempts` = `number`**: How many attempts to start the service before considering it as FinishedFailed. Default is
-    10.
-  Attempts are useful if your service is failing too quickly. If you're in a start-stop loop, this will put and end to
-  it.
-  If a service has failed too quickly and attempts > 0, it will be restarted even if the strategy is `never`.
-  And if the attempts are over, it will never be restarted even if the restart policy is: `On-Failure`/`Always`.
+* **`attempts` = `number`**: A budget that bounds how many times a service can fail *rapidly* (before it
+    becomes stable) before it's considered `FinishedFailed`. Default is `0`, which means **unbounded**
+    (the service is restarted forever according to its `strategy`).
+  Attempts are useful when a service is failing too quickly: if you're in a start-stop loop, this puts an
+    end to it. The budget applies to all three strategies:
+    * For `always` and `on-failure`, `attempts > 0` bounds the rapid-restart loop; `attempts = 0` keeps
+      restarting forever.
+    * For `never`, `attempts > 0` allows the service to be restarted up to that many times *only* when it
+      fails too quickly; with `attempts = 0` a `never` service is never restarted on failure.
+  In every case, once the budget is exhausted the service is no longer restarted, and it terminates as
+    `FinishedFailed` (or `Finished`, if its last exit was successful).
 
 The delay between attempts is calculated as: `backoff * attempts_made + start-delay`. For instance, using:
 
@@ -136,10 +142,12 @@ Will wait 1 second and then start the service. If it doesn't start:
 * 3d and last attempt will start after 1*3 +1 = 4 seconds.
 
 If the attempts are over, then the service will be considered FailedFinished and won't be restarted.
-The attempt count is reset as soon as the service's state changes to running.
-This state change is driven by the health-check component, and a service with no health-check will be considered as
-`Healthy` and it will
-immediately pass to the running state.
+The attempt count counts only *rapid* failures (failures that happen before the service becomes stable),
+and it is reset as soon as the service's state changes to running (i.e. it becomes "green").
+This state change is driven by the health-check component: a service with no health-check is considered
+`Healthy` and passes to the running state after `healthiness.healthy-after` (immediately by default, see
+the Healthiness section). Configure `healthy-after` to define how long a crash-prone service must survive
+before its restart budget is reset.
 
 ### Healthiness Check
 
@@ -149,6 +157,7 @@ http-endpoint = "http://localhost:8080/healthcheck"
 file-path = "/var/myservice/up"
 command = "curl -s localhost:8080/healthcheck"
 max-failed = 3
+healthy-after = "0s"
 ```
 
 * **`http-endpoint` = `<http endpoint>`**: It will send an HEAD request to the specified http endpoint. 200 means the
@@ -159,6 +168,11 @@ max-failed = 3
 * **`command` = `your_command arg1 arg2 ...`**: It will run this command. If the exit status is 0, the service is
   considered healthy.
 * **`max-failed` = `i32`**: How many unhealthy health-checks in a row are allowed before considering the service failed.
+* **`healthy-after` = `string`**: How long the process must stay alive before it's considered healthy (and
+  thus stably running, which resets the `restart.attempts` budget). Defaults to `0s`, meaning the service
+  is considered healthy immediately. This is most useful for services without an explicit health-check:
+  raising it lets a crash loop deterministically exhaust its restart budget instead of resetting it on
+  every quick (re)start.
 * You can check the healthiness of your system using a http endpoint or a flag file.
 * You can use the enforce dependency to kill every dependent system.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,10 @@ attempts = 0
     becomes stable) before it's considered `FinishedFailed`. Default is `0`, which means **unbounded**
     (the service is restarted forever according to its `strategy`).
   Attempts are useful when a service is failing too quickly: if you're in a start-stop loop, this puts an
-    end to it. The budget applies to all three strategies:
+    end to it. A failure counts as "too quick" if it happens before the service became stable, i.e. before
+    it reached the `running` state - see `healthiness.healthy-after` below to control how long a service
+    must survive before it's considered stable. Failing to spawn the process at all (for instance, a
+    command that isn't found) also counts against the budget. The budget applies to all three strategies:
     * For `always` and `on-failure`, `attempts > 0` bounds the rapid-restart loop; `attempts = 0` keeps
       restarting forever.
     * For `never`, `attempts > 0` allows the service to be restarted up to that many times *only* when it

--- a/horust/src/horust/formats/service.rs
+++ b/horust/src/horust/formats/service.rs
@@ -312,6 +312,11 @@ pub struct Healthiness {
     #[serde(default = "Healthiness::default_max_failed")]
     // todo: use an u32
     pub max_failed: i32,
+    /// For services without an explicit healthcheck, how long the process must stay
+    /// alive before it's considered healthy (and thus stably running). Defaults to 0s,
+    /// meaning the service is considered healthy immediately.
+    #[serde(default, with = "humantime_serde")]
+    pub healthy_after: Duration,
 }
 
 impl Healthiness {
@@ -331,6 +336,7 @@ impl Default for Healthiness {
             file_path: None,
             command: None,
             max_failed: 3,
+            healthy_after: Duration::from_secs(0),
         }
     }
 }
@@ -988,6 +994,22 @@ max-failed = 5
             Some("http://localhost:8080/health")
         );
         assert_eq!(svc.healthiness.max_failed, 5);
+    }
+
+    #[test]
+    fn test_healthy_after_defaults_and_parses() {
+        // Defaults to 0s when unspecified.
+        let svc: Service = Service::from_str(r#"command = "test""#).unwrap();
+        assert_eq!(svc.healthiness.healthy_after, Duration::from_secs(0));
+
+        // Parses a humantime duration.
+        let toml_str = r#"
+command = "test"
+[healthiness]
+healthy-after = "5s"
+"#;
+        let svc: Service = Service::from_str(toml_str).unwrap();
+        assert_eq!(svc.healthiness.healthy_after, Duration::from_secs(5));
     }
 
     use super::LogOutput;

--- a/horust/src/horust/healthcheck/mod.rs
+++ b/horust/src/horust/healthcheck/mod.rs
@@ -3,7 +3,7 @@
 
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossbeam::channel::{Receiver, RecvTimeoutError, Sender, unbounded};
 
@@ -20,6 +20,8 @@ struct Worker {
     service: Service,
     bus: BusConnector<Event>,
     work_done_notifier: Receiver<()>,
+    /// When the worker was spawned, used to enforce `healthiness.healthy-after`.
+    started_at: Instant,
 }
 
 impl Worker {
@@ -28,22 +30,39 @@ impl Worker {
             service,
             bus,
             work_done_notifier,
+            started_at: Instant::now(),
         }
     }
     pub fn spawn_thread(self) -> JoinHandle<()> {
         thread::spawn(move || self.run())
     }
     fn run(self) {
+        let healthy_after = self.service.healthiness.healthy_after;
+        let poll = Duration::from_millis(1000);
         loop {
+            let elapsed = self.started_at.elapsed();
             let status = check_health(&self.service.healthiness);
-            self.bus.send_event(Event::HealthCheck(
-                self.service.name.clone(),
-                status.clone(),
-            ));
-            match self
-                .work_done_notifier
-                .recv_timeout(Duration::from_millis(1000))
-            {
+            // Suppress the "healthy" signal until the service has been alive for at least
+            // `healthy-after`, so a crash within the window counts against the
+            // restart-attempts budget. We send *nothing* (rather than a synthetic
+            // Unhealthy) during the window: Unhealthy counts accumulate and are never
+            // decremented, which would permanently prevent the service becoming Running.
+            let suppress = status == HealthinessStatus::Healthy && elapsed < healthy_after;
+            if !suppress {
+                self.bus.send_event(Event::HealthCheck(
+                    self.service.name.clone(),
+                    status.clone(),
+                ));
+            }
+            // Inside the window, wake up at the boundary instead of only every `poll`, so
+            // the service turns green close to the configured time.
+            let timeout = if elapsed < healthy_after {
+                poll.min(healthy_after - elapsed)
+                    .max(Duration::from_millis(10))
+            } else {
+                poll
+            };
+            match self.work_done_notifier.recv_timeout(timeout) {
                 Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
                 _ => (),
             };
@@ -84,7 +103,11 @@ fn run(bus: BusConnector<Event>, services: Vec<Service>) {
         match ev {
             Event::StatusChanged(s_name, ServiceStatus::Started) => {
                 let service = get_service(&s_name);
-                if !service.healthiness.has_any_check_defined() {
+                // With no explicit check and no healthy-after delay, the service is healthy
+                // immediately; otherwise a worker enforces them before reporting Healthy.
+                if !service.healthiness.has_any_check_defined()
+                    && service.healthiness.healthy_after.is_zero()
+                {
                     bus.send_event(Event::HealthCheck(s_name, HealthinessStatus::Healthy));
                     continue;
                 }

--- a/horust/src/horust/supervisor/mod.rs
+++ b/horust/src/horust/supervisor/mod.rs
@@ -169,6 +169,10 @@ impl Supervisor {
             Event::Run(service_name) if self.repo.get_sh(&service_name).is_initial() => {
                 let service_handler = self.repo.get_mut_sh(&service_name);
                 service_handler.status = ServiceStatus::Starting;
+                // Health check results from a previous run must not carry over to the new
+                // process, otherwise a service that was healthy before would immediately
+                // be considered green again (skipping its `healthy-after` window).
+                service_handler.healthiness_checks_failed = None;
                 let evs = vec![Event::StatusChanged(service_name, ServiceStatus::Starting)];
 
                 let res = healthcheck::prepare_service(&service_handler.service().healthiness);

--- a/horust/src/horust/supervisor/mod.rs
+++ b/horust/src/horust/supervisor/mod.rs
@@ -206,6 +206,10 @@ impl Supervisor {
             }
             Event::SpawnFailed(s_name) => {
                 let service_handler = self.repo.get_mut_sh(&s_name);
+                // The process never came to exist, so no ServiceExited will ever arrive to
+                // account for this failure. Count it here, otherwise a service that can
+                // never be spawned (e.g. command not found) would restart forever.
+                service_handler.restart_attempts += 1;
                 service_handler.status = ServiceStatus::Failed;
                 vec![Event::StatusUpdate(s_name, ServiceStatus::Failed)]
             }

--- a/horust/src/horust/supervisor/service_handler.rs
+++ b/horust/src/horust/supervisor/service_handler.rs
@@ -259,8 +259,10 @@ fn handle_status_change(
 
     if valid {
         match next_status {
-            Started => {
-                new_service_handler.status = Started;
+            // The budget is reset only once the service is genuinely stable (green), i.e.
+            // on Running - not on Started - so crash loops do exhaust it.
+            Running => {
+                new_service_handler.status = Running;
                 new_service_handler.restart_attempts = 0;
             }
             InKilling if service_handler.status == Initial => {
@@ -291,23 +293,21 @@ fn handle_status_change(
 
 /// Produces events based on the Restart Strategy of the service.
 fn handle_restart_strategy(service_handler: &ServiceHandler, is_failed: bool) -> Event {
+    use ServiceStatus::*;
+    let attempts_over = service_handler.restart_attempts_are_over();
+    // on-failure/always restart by default, so a budget only bounds them when set (>0);
+    // never only restarts as a rapid-failure escape hatch, bounded by any (even 0) budget.
+    let bounded = service_handler.service.restart.attempts > 0 && attempts_over;
+    let restart_or_fail = |stop: bool| if stop { FinishedFailed } else { Initial };
     let new_status = match service_handler.service.restart.strategy {
-        RestartStrategy::Never if is_failed => {
-            debug!(
-                "restart attempts: {}, are over: {}, max: {}",
-                service_handler.restart_attempts,
-                service_handler.restart_attempts_are_over(),
-                service_handler.service.restart.attempts
-            );
-            if service_handler.restart_attempts_are_over() {
-                ServiceStatus::FinishedFailed
-            } else {
-                ServiceStatus::Initial
-            }
+        RestartStrategy::Never if is_failed => restart_or_fail(attempts_over),
+        RestartStrategy::OnFailure | RestartStrategy::Always if is_failed => {
+            restart_or_fail(bounded)
         }
-        RestartStrategy::OnFailure if is_failed => ServiceStatus::Initial,
-        RestartStrategy::Never | RestartStrategy::OnFailure => ServiceStatus::Finished,
-        RestartStrategy::Always => ServiceStatus::Initial,
+        // A successful exit is only restarted by `always`, and only while the budget lasts:
+        // FinishedFailed is not a legal transition from Success, so give up as Finished.
+        RestartStrategy::Always if !bounded => Initial,
+        RestartStrategy::Never | RestartStrategy::OnFailure | RestartStrategy::Always => Finished,
     };
     debug!("Restart strategy applied, ev: {:?}", new_status);
     Event::new_status_update(service_handler.name(), new_status)
@@ -405,6 +405,73 @@ strategy = "{}"
                 let received = handle_restart_strategy(&sh, has_failed);
                 assert_eq!(received, expected);
             });
+    }
+
+    #[test]
+    fn test_handle_restart_strategy_honors_attempts_budget() {
+        let ev = |status| Event::new_status_update("servicename", status);
+        let make = |strategy: &str, restart_attempts: u32| {
+            let service: Service = Service::from_str(&format!(
+                r#"name="servicename"
+command = "Not relevant"
+[restart]
+strategy = "{strategy}"
+attempts = 3
+"#
+            ))
+            .unwrap();
+            let mut sh: ServiceHandler = service.into();
+            sh.restart_attempts = restart_attempts;
+            sh
+        };
+
+        // on-failure and always restart while the budget remains, then FinishedFailed.
+        for strategy in ["on-failure", "always"] {
+            assert_eq!(
+                handle_restart_strategy(&make(strategy, 3), true),
+                ev(ServiceStatus::Initial),
+                "{strategy} should restart while budget remains"
+            );
+            assert_eq!(
+                handle_restart_strategy(&make(strategy, 4), true),
+                ev(ServiceStatus::FinishedFailed),
+                "{strategy} should stop once budget is exhausted"
+            );
+        }
+
+        // A successful exit never yields FinishedFailed: that is not a legal transition
+        // from Success, so an exhausted `always` service terminates as Finished instead.
+        assert_eq!(
+            handle_restart_strategy(&make("always", 3), false),
+            ev(ServiceStatus::Initial)
+        );
+        assert_eq!(
+            handle_restart_strategy(&make("always", 4), false),
+            ev(ServiceStatus::Finished)
+        );
+    }
+
+    #[test]
+    fn test_handle_restart_strategy_unbounded_when_attempts_zero() {
+        let ev = |status| Event::new_status_update("servicename", status);
+        for strategy in ["on-failure", "always"] {
+            let service: Service = Service::from_str(&format!(
+                r#"name="servicename"
+command = "Not relevant"
+[restart]
+strategy = "{strategy}"
+attempts = 0
+"#
+            ))
+            .unwrap();
+            let mut sh: ServiceHandler = service.into();
+            sh.restart_attempts = 100;
+            assert_eq!(
+                handle_restart_strategy(&sh, true),
+                ev(ServiceStatus::Initial),
+                "{strategy} with attempts=0 should restart unboundedly"
+            );
+        }
     }
 
     #[test]
@@ -564,20 +631,23 @@ wait = "10s"
     }
 
     #[test]
-    fn test_started_transition_resets_restart_attempts() {
+    fn test_started_transition_preserves_restart_attempts() {
+        // The budget is no longer reset on Started, only once the service is stable
+        // (Running). This ensures crash loops that never stabilize exhaust the budget.
         let mut sh = make_handler("svc", ServiceStatus::Starting);
         sh.restart_attempts = 5;
         let (new_sh, new_status) = sh.change_status(ServiceStatus::Started);
         assert_eq!(new_status, ServiceStatus::Started);
-        assert_eq!(new_sh.restart_attempts, 0);
+        assert_eq!(new_sh.restart_attempts, 5);
     }
 
     #[test]
-    fn test_non_started_transition_preserves_restart_attempts() {
+    fn test_running_transition_resets_restart_attempts() {
         let mut sh = make_handler("svc", ServiceStatus::Started);
         sh.restart_attempts = 3;
-        let (new_sh, _) = sh.change_status(ServiceStatus::Running);
-        assert_eq!(new_sh.restart_attempts, 3);
+        let (new_sh, new_status) = sh.change_status(ServiceStatus::Running);
+        assert_eq!(new_status, ServiceStatus::Running);
+        assert_eq!(new_sh.restart_attempts, 0);
     }
 
     // ========================================================================

--- a/horust/tests/section_restart.rs
+++ b/horust/tests/section_restart.rs
@@ -86,6 +86,142 @@ strategy = "on-failure"
     recv.recv_or_kill(Duration::from_secs(15));
 }
 
+/// Runs an always-failing service and returns (horust exit status, number of launches).
+fn run_bounded_crash_loop(strategy: &str, attempts: u32) -> (std::process::ExitStatus, usize) {
+    let (mut cmd, temp_dir) = get_cli();
+    let attempts_log = temp_dir.path().join("attempts.log");
+    let always_failing_script = format!(
+        r#"#!/usr/bin/env bash
+printf 'run\n' >> "{}"
+exit 1
+"#,
+        attempts_log.display()
+    );
+    // healthy-after keeps the service in the not-yet-green state long enough that each
+    // immediate crash counts against the restart budget, making the bound deterministic.
+    let service = format!(
+        r#"
+[restart]
+attempts = {attempts}
+backoff = "1ms"
+strategy = "{strategy}"
+
+[healthiness]
+healthy-after = "10s"
+
+[failure]
+successful-exit-code = [0]
+strategy = "ignore"
+"#
+    );
+    store_service_script(
+        temp_dir.path(),
+        &always_failing_script,
+        Some(&service),
+        None,
+    );
+
+    let mut child = cmd
+        .arg("--unsuccessful-exit-finished-failed")
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            let launches = std::fs::read_to_string(&attempts_log)
+                .map(|contents| contents.lines().count())
+                .unwrap_or(0);
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("Horust did not stop after {launches} launches");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let launches = std::fs::read_to_string(attempts_log)
+        .unwrap()
+        .lines()
+        .count();
+    (status, launches)
+}
+
+#[test]
+fn test_restart_strategy_on_failure_exhausts_attempts() {
+    let (status, launches) = run_bounded_crash_loop("on-failure", 3);
+    assert_eq!(status.code(), Some(101));
+    assert_eq!(launches, 4, "initial launch plus three retries");
+}
+
+#[test]
+fn test_restart_strategy_always_exhausts_attempts() {
+    let (status, launches) = run_bounded_crash_loop("always", 3);
+    assert_eq!(status.code(), Some(101));
+    assert_eq!(launches, 4, "initial launch plus three retries");
+}
+
+/// A service that survives past `healthy-after` becomes stable, resetting its restart
+/// budget. It must therefore keep restarting on failure rather than being bounded.
+#[test]
+fn test_healthy_after_resets_restart_budget() {
+    let (mut cmd, temp_dir) = get_cli();
+    let attempts_log = temp_dir.path().join("attempts.log");
+    // Sleeps past healthy-after (so it reaches Running and resets the budget) before
+    // failing. With attempts = 2 this would exhaust quickly if the budget never reset.
+    let script = format!(
+        r#"#!/usr/bin/env bash
+count=0
+[ -f "{0}" ] && count=$(wc -l < "{0}")
+printf 'run\n' >> "{0}"
+sleep 0.5
+if [ "$count" -lt 4 ]; then
+    exit 1
+fi
+sleep 60
+"#,
+        attempts_log.display()
+    );
+    let service = r#"
+[restart]
+attempts = 2
+backoff = "1ms"
+strategy = "on-failure"
+
+[healthiness]
+healthy-after = "100ms"
+
+[failure]
+successful-exit-code = [0]
+strategy = "ignore"
+"#;
+    store_service_script(temp_dir.path(), &script, Some(service), None);
+
+    let mut child = cmd
+        .arg("--unsuccessful-exit-finished-failed")
+        .spawn()
+        .unwrap();
+
+    // Give it time to fail several times and then stabilize. If the budget were not
+    // reset on reaching a stable state, Horust would have exited (FinishedFailed) after
+    // 3 launches; instead it should keep restarting past the budget and still be running.
+    std::thread::sleep(Duration::from_secs(6));
+    let still_running = child.try_wait().unwrap().is_none();
+    let launches = std::fs::read_to_string(&attempts_log)
+        .map(|c| c.lines().count())
+        .unwrap_or(0);
+    child.kill().unwrap();
+    child.wait().unwrap();
+    assert!(
+        still_running,
+        "Horust exited early after {launches} launches; the budget was not reset on reaching a stable state"
+    );
+    assert!(
+        launches > 3,
+        "expected more than the 3 allowed launches (initial + 2 retries), got {launches}"
+    );
+}
+
 /// With restart strategy set to always, the child service should be always restarted regardless of
 /// the reason why it exited.
 fn test_restart_always_signal(signal: i32) -> Result<(), std::io::Error> {

--- a/horust/tests/section_restart.rs
+++ b/horust/tests/section_restart.rs
@@ -86,6 +86,26 @@ strategy = "on-failure"
     recv.recv_or_kill(Duration::from_secs(15));
 }
 
+/// Waits for horust to exit on its own, panicking with `on_timeout` if it keeps running.
+fn wait_for_exit(
+    child: &mut std::process::Child,
+    on_timeout: impl FnOnce() -> String,
+) -> std::process::ExitStatus {
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        if std::time::Instant::now() >= deadline {
+            let msg = on_timeout();
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("{msg}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
 /// Runs an always-failing service and returns (horust exit status, number of launches).
 fn run_bounded_crash_loop(strategy: &str, attempts: u32) -> (std::process::ExitStatus, usize) {
     let (mut cmd, temp_dir) = get_cli();
@@ -125,26 +145,38 @@ strategy = "ignore"
         .arg("--unsuccessful-exit-finished-failed")
         .spawn()
         .unwrap();
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    let status = loop {
-        if let Some(status) = child.try_wait().unwrap() {
-            break status;
-        }
-        if std::time::Instant::now() >= deadline {
-            let launches = std::fs::read_to_string(&attempts_log)
-                .map(|contents| contents.lines().count())
-                .unwrap_or(0);
-            child.kill().unwrap();
-            child.wait().unwrap();
-            panic!("Horust did not stop after {launches} launches");
-        }
-        std::thread::sleep(Duration::from_millis(20));
+    let count_launches = || {
+        std::fs::read_to_string(&attempts_log)
+            .map(|contents| contents.lines().count())
+            .unwrap_or(0)
     };
-    let launches = std::fs::read_to_string(attempts_log)
-        .unwrap()
-        .lines()
-        .count();
-    (status, launches)
+    let status = wait_for_exit(&mut child, || {
+        format!("Horust did not stop after {} launches", count_launches())
+    });
+    (status, count_launches())
+}
+
+/// A service whose command cannot be spawned at all (not found in PATH) fails before the
+/// process ever exists, so there is no exit to observe. It must still consume the restart
+/// budget, otherwise it would be restarted forever.
+#[test]
+fn test_spawn_failure_exhausts_attempts() {
+    let (mut cmd, temp_dir) = get_cli();
+    let service = r#"command = "definitely-not-a-real-binary-xyz"
+[restart]
+attempts = 2
+backoff = "1ms"
+strategy = "on-failure"
+"#;
+    std::fs::write(temp_dir.path().join("svc.toml"), service).unwrap();
+    let mut child = cmd
+        .arg("--unsuccessful-exit-finished-failed")
+        .spawn()
+        .unwrap();
+    let status = wait_for_exit(&mut child, || {
+        "Horust kept restarting a service that could never be spawned".to_string()
+    });
+    assert_eq!(status.code(), Some(101));
 }
 
 #[test]


### PR DESCRIPTION
Bound repeated post-start crashes so  restart.attempts  is honored by all restart strategies, reset the budget only once a service is genuinely stable, and add a configurable  healthiness.healthy-after  stable interval.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #318.
`restart.attempts` was documented as a bound on rapid restart loops, but the implementation diverged from that intent in three ways:

1. The budget was ignored by  on-failure  and  always .  handle_restart_strategy  only consulted  restart_attempts_are_over()  for the  never  strategy, so a crashing  on-failure / always  service restarted forever regardless of  attempts .
2. The counter reset too early.  restart_attempts  was reset on the  Started  transition. For a service with no healthcheck,  Started → Running  happens immediately, so a tight crash loop reset its budget on every respawn and never exhausted it.
3. Docs were out of sync (claimed a default of  10  and that  on-failure  honored attempts; the real default is  0  and it did not).

### Description
`handle_restart_strategy` now applies the budget check to all three strategies, so an exhausted service goes to `FinishedFailed` instead of restarting forever; `attempts = 0~ still means unbounded, so the default behavior is unchanged. The `restart_attempts` reset moves from the `Started` to the `Running` transition, so only a service that actually becomes stable clears its budget. A new  healthiness.healthy-after  duration (default  0s ) makes "stable" configurable for services without an explicit healthcheck by delaying `Healthy` until that much uptime has elapsed, with stale health cleared on relaunch. Docs are corrected accordingly, and unit and integration tests cover the budget across strategies, the reset semantics, `healthy-after` parsing, and crash loops terminating after exhausting their attempts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Unit and integ tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
